### PR TITLE
Allow visiting the original provider URL

### DIFF
--- a/ui/src/components/table/ProviderTable.js
+++ b/ui/src/components/table/ProviderTable.js
@@ -12,10 +12,6 @@ const emptyTable = () => {
   );
 };
 
-const truncate = (str, n) => {
-  return str.length > n ? str.substr(0, n - 1) + '…' : str;
-};
-
 const content = (providerData, onRemove) => {
   return (
     <Fragment>
@@ -23,7 +19,11 @@ const content = (providerData, onRemove) => {
         return (
           <Table.Row key={data.id}>
             <Table.Cell>{data.name}</Table.Cell>
-            <Table.Cell>{truncate(data.url, 60)}</Table.Cell>
+            <Table.Cell>
+              <a href={data.url} target="_blank" rel="noopener noreferrer">
+                Visit site
+              </a>
+            </Table.Cell>
             <Table.Cell>
               <div style={{ float: 'right' }}>
                 <Button circular color="red" icon="trash" onClick={() => onRemove(data.id)} />


### PR DESCRIPTION
Instead of truncating the original URL of each provider in the job configuration to 60 characters and losing a lot of context information, put a link to the original URL in the provider table which can be opened directly to verify what is being scraped by Fredy.

**Before**
<img width="788" alt="Screenshot before the change" src="https://user-images.githubusercontent.com/43951/150973764-9a25fec0-b885-4563-b0e3-3b42cac8b76f.png">

**After**
<img width="788" alt="Screenshot after the change" src="https://user-images.githubusercontent.com/43951/150973494-4938b505-dc51-425f-8107-a1695333fe94.png">
