### PR TITLE
Fix race condition if user ID is in session but not in user store

### DIFF
--- a/lib/api/routes/loginRoute.js
+++ b/lib/api/routes/loginRoute.js
@@ -5,13 +5,13 @@ const hasher = require('../../services/security/hash');
 
 loginRouter.get('/user', async (req, res) => {
   const currentUserId = req.session.currentUser;
-  const isAdmin = currentUserId == null ? false : userStorage.getUser(currentUserId).isAdmin;
-  if (currentUserId == null) {
+  const currentUser = currentUserId == null ? null : userStorage.getUser(currentUserId);
+  if (currentUser == null) {
     res.body = {};
   } else {
     res.body = {
-      userId: currentUserId,
-      isAdmin,
+      userId: currentUser.id,
+      isAdmin: currentUser.isAdmin,
     };
   }
   res.send();


### PR DESCRIPTION
Fix a race condition during login if a user ID is in the local session but no user exists in the user store.

This mostly happens during testing when removing the "database" between runs but not closing the browser window or removing cookies for `localhost`.

Related stack trace:
```
/path/to/fredy/lib/api/routes/loginRoute.js:8
  const isAdmin = currentUserId == null ? false : userStorage.getUser(currentUserId).isAdmin;
                                                                                    ^

TypeError: Cannot read properties of null (reading 'isAdmin')
    at /path/to/fredy/lib/api/routes/loginRoute.js:8:85
    at next (/path/to/fredy/node_modules/0http/lib/next.js:32:14)
    at Trouter.router.lookup (/path/to/fredy/node_modules/0http/lib/router/sequential.js:93:14)
    at Object.service.lookup (/path/to/fredy/node_modules/restana/libs/request-router.js:75:49)
    at next (/path/to/fredy/node_modules/0http/lib/next.js:30:25)
    at step (/path/to/fredy/node_modules/0http/lib/next.js:15:14)
    at SendStream.error (/path/to//fredy/node_modules/serve-static/index.js:121:7)
    at SendStream.emit (node:events:520:28)
    at SendStream.error (/path/to/fredy/node_modules/send/index.js:270:17)
    at SendStream.onStatError (/path/to/fredy/node_modules/send/index.js:421:12)
    at next (/path/to/fredy/node_modules/send/index.js:735:16)
    at onstat (/path/to/fredy/node_modules/send/index.js:724:14)
    at FSReqCallback.oncomplete (node:fs:198:21)
```