### PR TITLE
Telegram: Use job name instead of ID and link in title

### DIFF
--- a/lib/notification/adapter/telegram.js
+++ b/lib/notification/adapter/telegram.js
@@ -1,4 +1,5 @@
 const { markdown2Html } = require('../../services/markdown');
+const { getJob } = require('../../services/storage/jobStorage');
 const axios = require('axios');
 
 /**
@@ -19,23 +20,24 @@ const arrayChunks = (inputArray, perChunk) =>
  * @param serviceName e.g immowelt
  * @param newListings an array with newly found listings
  * @param notificationConfig config of this notification adapter
- * * @param jobKey name of the current job that is being executed
+ * @param jobKey name of the current job that is being executed
  * @returns {Promise<Void> | void}
  */
 exports.send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
   const { token, chatId } = notificationConfig.find((adapter) => adapter.id === 'telegram').fields;
+  const job = getJob(jobKey);
+  const jobName = job == null ? jobKey : job.name;
 
   //we have to split messages into chunk, because otherwise messages are going to become too big and will fail
   const chunks = arrayChunks(newListings, 3);
 
   const promises = chunks.map((chunk) => {
-    let message = `Job: ${jobKey} | Service <b>${serviceName}</b> found <b>${newListings.length}</b> new listings:\n\n`;
+    let message = `<i>${jobName}</i> (${serviceName}) found <b>${newListings.length}</b> new listings:\n\n`;
     message += chunk.map(
       (o) =>
-        `<b>${shorten(o.title.replace(/\*/g, ''), 45)}</b>\n` +
+        `<a href="${o.link}"><b>${shorten(o.title.replace(/\*/g, ''), 45).trim()}</b></a>\n` +
         [o.address, o.price, o.size].join(' | ') +
-        '\n' +
-        `<a href="${o.link}">${o.link}</a>\n\n`
+        '\n\n'
     );
 
     return axios.post(`https://api.telegram.org/bot${token}/sendMessage`, {


### PR DESCRIPTION
This PR improves the message formatting of the Telegram notification adapter.

The Telegram notification adapter is currently using the job ID (`jobKey`) in its message which is just a random, unique string. This makes it harder than necessary for humans to identify which job a listing originated from:
<img width="512" alt="Telegram notification with job ID" src="https://user-images.githubusercontent.com/43951/151140348-374aaedd-d589-4bed-b83a-7410371dc562.png">

The changes in this PR try to resolve the actual job name in the Telegram notification adapter and fall back to the job ID (`jobKey`) if the job name couldn't be resolved.

Additionally, the link to the listing is being combined with the title to make more use of the screen estate.

**Before**
<img width="334" alt="Telegram notification before the change" src="https://user-images.githubusercontent.com/43951/151140224-e450397b-2594-4567-9d06-2b0caf662e36.png">

**After**
<img width="248" alt="Telegram notification after the change" src="https://user-images.githubusercontent.com/43951/151140257-c1b75617-8841-46a1-ab8b-272a44a0af6a.png">