### PR TITLE
added run-script-os for win compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "[F]ind [R]eal [E]states [d]amn eas[y].",
   "scripts": {
     "start": "node index.js",
-    "dev": "yarn && export BUILD_DEV='true' && export NODE_ENV='development' && webpack serve --progress --color --config ./webpack.dev.js",
-    "prod": "export BUILD_DEV='false' && webpack --node-env=production --config ./webpack.prod.js",
+    "dev": "run-script-os",
+    "dev:win32": "yarn && set BUILD_DEV='true' && set NODE_ENV='development' && webpack serve --progress --color --config ./webpack.dev.js",
+    "dev:default": "yarn && export BUILD_DEV='true' && export NODE_ENV='development' && webpack serve --progress --color --config ./webpack.dev.js",
+    "prod": "run-script-os",
+    "prod:win32": "set BUILD_DEV='false' && webpack --node-env=production --config ./webpack.prod.js",
+    "prod:default": "export BUILD_DEV='false' && webpack --node-env=production --config ./webpack.prod.js",
     "format": "prettier --write lib/**/*.js ui/src/**/*.js test/**/*.js *.js --single-quote --print-width 120",
     "test": "mocha --timeout 20000 test/**/*.test.js",
     "lint": "eslint ./index.js ./lib/**/*.js ./test/**/*.js"
@@ -107,6 +111,7 @@
     "prettier": "2.6.1",
     "proxyquire": "2.1.3",
     "redux-logger": "3.0.6",
+    "run-script-os": "^1.1.6",
     "style-loader": "3.3.1",
     "url-loader": "4.1.1",
     "webpack": "5.70.0",


### PR DESCRIPTION
closes #51 
Win uses "set" instead of unix's "export"
To make it dynamic I followed @orangecoding 's advice and used run-script-os https://www.npmjs.com/package/run-script-os

I have only tested on windows if `yarn run prod` and `yarn run dev` still work.
I have not run the tests and I have not checked the dependency management is correct.
Also I forked the repo since I lacked access rights to the main repo...

Tests still green (obviously)