### PR TITLE
Delay Telegram message sending to prevent HTTP 429 responses

### DIFF
--- a/lib/notification/adapter/telegram.js
+++ b/lib/notification/adapter/telegram.js
@@ -15,6 +15,40 @@ const arrayChunks = (inputArray, perChunk) =>
     return all;
   }, []);
 
+const messageHeader = (jobName, serviceName, newListingsCount) => 
+  `<i>${jobName}</i> (${serviceName}) found <b>${newListingsCount}</b> new listings:\n\n`;
+
+const chunkToHtml = (chunk) => chunk.map(
+  (o) =>
+    `<a href="${o.link}"><b>${shorten(o.title.replace(/\*/g, ''), 45).trim()}</b></a>\n` +
+    [o.address, o.price, o.size].join(' | ') +
+    '\n\n'
+  );
+
+/**
+ * Executes the given asyncFunctions sequentially, waits for each function to finish
+ * and adds a delay before executing the next one.
+ * @param maxPerSecond 
+ * @param maxPerMinute 
+ * @param asyncFunctions 
+ */
+const executeDelayed = async (maxPerSecond, maxPerMinute, asyncFunctions) => {
+  const timeSeconds = seconds => new Promise(res => setTimeout(res, seconds * 1000));
+  let secondTimer = timeSeconds(1);
+  let minuteTimer = timeSeconds(60);
+  for(let i = 1; i <= asyncFunctions.length; i++){
+    await asyncFunctions[i - 1]();
+    if(i % maxPerSecond === 0){
+      await secondTimer;
+      secondTimer = timeSeconds(1);
+    }
+    if(i % maxPerMinute === 0){
+      await minuteTimer;
+      minuteTimer = timeSeconds(60);
+    }
+  }
+};
+
 /**
  * sends new listings to telegram
  * @param serviceName e.g immowelt
@@ -23,7 +57,7 @@ const arrayChunks = (inputArray, perChunk) =>
  * @param jobKey name of the current job that is being executed
  * @returns {Promise<Void> | void}
  */
-exports.send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
+exports.send = async ({ serviceName, newListings, notificationConfig, jobKey }) => {
   const { token, chatId } = notificationConfig.find((adapter) => adapter.id === 'telegram').fields;
   const job = getJob(jobKey);
   const jobName = job == null ? jobKey : job.name;
@@ -31,24 +65,19 @@ exports.send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
   //we have to split messages into chunk, because otherwise messages are going to become too big and will fail
   const chunks = arrayChunks(newListings, 3);
 
-  const promises = chunks.map((chunk) => {
-    let message = `<i>${jobName}</i> (${serviceName}) found <b>${newListings.length}</b> new listings:\n\n`;
-    message += chunk.map(
-      (o) =>
-        `<a href="${o.link}"><b>${shorten(o.title.replace(/\*/g, ''), 45).trim()}</b></a>\n` +
-        [o.address, o.price, o.size].join(' | ') +
-        '\n\n'
-    );
+  const htmlMessages = 
+    chunks.map((chunk) => messageHeader(jobName, serviceName, newListings.length) + chunkToHtml(chunk));
 
-    return axios.post(`https://api.telegram.org/bot${token}/sendMessage`, {
+  // do not send more than one message per second
+  // and not more than 20 per minute
+  await executeDelayed(1, 20, htmlMessages.map(
+    (htmlMessage) => () => axios.post(`https://api.telegram.org/bot${token}/sendMessage`, {
       chat_id: chatId,
-      text: message,
+      text: htmlMessage,
       parse_mode: 'HTML',
       disable_web_page_preview: true,
-    });
-  });
-
-  return Promise.all(promises);
+    })
+  ));
 };
 
 function shorten(str, len = 30) {


### PR DESCRIPTION
In order to prevent HTTP 429 responses the telegram adapter should not send more than 1 message per second and not more than 20 messsages per minute (see https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this).
#57 