### PR TITLE
Update the Telegram adapter to add a rich message option with a photo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ db/
 npm-debug.log
 .DS_Store
 .idea
+.vscode/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ function applyBlacklist(o) {
 
 const config = {
   url: null,
-    //this is the container wrapping the search listings
+  //this is the container wrapping the search listings
   crawlContainer: '#result-list-stage .item',
   crawlFields: {
     id: '@id',
@@ -36,6 +36,9 @@ const config = {
     title: '.item a img@title',
     link: 'a[id*="lnkImgToDetails_"]@href',
     address: '.item .box-25 .ellipsis .text-100 | removeNewline | trim',
+    image: 'img@src',
+    //some websites provide image URLs for rendered ads only and lazy URLs for the rest
+    lazyImage: 'lazyImg@src'
   },
   paginate: '#idResultList .margin-bottom-6.margin-bottom-sm-12 .panel a.pull-right@href',
   normalize: normalize,

--- a/lib/api/routes/notificationAdapterRouter.js
+++ b/lib/api/routes/notificationAdapterRouter.js
@@ -35,6 +35,22 @@ notificationAdapterRouter.post('/try', async (req, res) => {
           size: '666 2m',
           link: 'https://www.orange-coding.net',
         },
+        {
+          price: '1500 €',
+          title:
+            'This is a test listing with long and doubled title. This is a test listing with long and doubled title.',
+          address: 'some address',
+          size: '777 2m',
+          link: 'https://www.orange-coding.net',
+        },
+        {
+          price: '2500 €',
+          title: 'This is a test listing with an image',
+          address: 'some address',
+          size: '555 2m',
+          link: 'https://www.orange-coding.net',
+          image: 'https://images.pexels.com/photos/106399/pexels-photo-106399.jpeg',
+        },
       ],
       notificationConfig,
       jobKey: 'TestJob',

--- a/lib/notification/adapter/apprise.js
+++ b/lib/notification/adapter/apprise.js
@@ -8,7 +8,7 @@ export const send = ({ serviceName, newListings, notificationConfig, jobKey }) =
   const jobName = job == null ? jobKey : job.name;
   const promises = newListings.map((newListing) => {
     const title = `${jobName} at ${serviceName}: ${newListing.title}`;
-    const message = `Address: ${newListing.address}\nSize: ${newListing.size}\nPrice: ${newListing.price}\Link: ${newListing.link}`;
+    const message = `Address: ${newListing.address}\nSize: ${newListing.size}\nPrice: ${newListing.price}\nLink: ${newListing.link}`;
     return fetch(server, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/lib/notification/adapter/telegram.js
+++ b/lib/notification/adapter/telegram.js
@@ -15,10 +15,83 @@ const arrayChunks = (inputArray, perChunk) =>
     all[ch] = [].concat(all[ch] || [], one);
     return all;
   }, []);
-function shorten(str, len = 30) {
+
+function shorten(str, len = 45) {
   return str.length > len ? str.substring(0, len) + '...' : str;
 }
-export const send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
+
+function isValidURL(url) {
+  try {
+    new URL(url);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+const sendTelegramMessage = (token, chatId, message, isPhoto = false, photoUrl = '') => {
+  const url = isPhoto
+    ? `https://api.telegram.org/bot${token}/sendPhoto`
+    : `https://api.telegram.org/bot${token}/sendMessage`;
+  const body = isPhoto
+    ? JSON.stringify({
+        chat_id: chatId,
+        photo: photoUrl,
+        caption: message,
+        parse_mode: 'HTML',
+      })
+    : JSON.stringify({
+        chat_id: chatId,
+        text: message,
+        parse_mode: 'HTML',
+        disable_web_page_preview: !isPhoto,
+      });
+
+  /**
+   * This is to not break the rate limit. It is to only send 1 message per second
+   */
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      fetch(url, {
+        method: 'post',
+        body: body,
+        headers: { 'Content-Type': 'application/json' },
+      })
+        .then(() => {
+          resolve();
+        })
+        .catch(() => {
+          reject();
+        });
+    }, RATE_LIMIT_INTERVAL);
+  });
+};
+
+const sendRichMessage = ({ serviceName, newListings, notificationConfig, jobKey }) => {
+  const { token, chatId } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
+  const job = getJob(jobKey);
+  const jobName = job == null ? jobKey : job.name;
+
+  const promises = newListings.map((o, index) => {
+    let message = '';
+    /**
+     * Only send the job information once
+     */
+    if (index === 0) {
+      message += `<i>${jobName}</i> (${serviceName}) found <b>${newListings.length}</b> new listings:\n\n`;
+    }
+    message +=
+      `<a href='${o.link}'><b>${shorten(o.title.replace(/\*/g, '')).trim()}</b></a>\n` +
+      `🏠 Address: ${o.address}\n` +
+      `💰 Price: ${o.price}\n` +
+      `📐 Size: ${o.size}\n`;
+    const imageURL = o.lazyImage || o.image;
+    return sendTelegramMessage(token, chatId, message, imageURL && isValidURL(imageURL), imageURL);
+  });
+  return Promise.all(promises);
+};
+
+const sendPlainMessage = ({ serviceName, newListings, notificationConfig, jobKey }) => {
   const { token, chatId } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
   const job = getJob(jobKey);
   const jobName = job == null ? jobKey : job.name;
@@ -26,38 +99,27 @@ export const send = ({ serviceName, newListings, notificationConfig, jobKey }) =
   const chunks = arrayChunks(newListings, MAX_ENTITIES_PER_CHUNK);
   const promises = chunks.map((chunk) => {
     let message = `<i>${jobName}</i> (${serviceName}) found <b>${newListings.length}</b> new listings:\n\n`;
-    message += chunk.map(
-      (o) =>
-        `<a href='${o.link}'><b>${shorten(o.title.replace(/\*/g, ''), 45).trim()}</b></a>\n` +
-        [o.address, o.price, o.size].join(' | ') +
-        '\n\n',
-    );
-    /**
-     * This is to not break the rate limit. It is to only send 1 message per second
-     */
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
-          method: 'post',
-          body: JSON.stringify({
-            chat_id: chatId,
-            text: message,
-            parse_mode: 'HTML',
-            disable_web_page_preview: true,
-          }),
-          headers: { 'Content-Type': 'application/json' },
-        })
-          .then(() => {
-            resolve();
-          })
-          .catch(() => {
-            reject();
-          });
-      }, RATE_LIMIT_INTERVAL);
-    });
+    message += chunk
+      .map(
+        (o) =>
+          `<a href='${o.link}'><b>${shorten(o.title.replace(/\*/g, '')).trim()}</b></a>\n` +
+          [o.address, o.price, o.size].join(' | '),
+      )
+      .join('\n\n');
+    return sendTelegramMessage(token, chatId, message);
   });
   return Promise.all(promises);
 };
+
+export const send = ({ serviceName, newListings, notificationConfig, jobKey }) => {
+  const { richMessage } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
+  if (richMessage) {
+    return sendRichMessage({ serviceName, newListings, notificationConfig, jobKey });
+  } else {
+    return sendPlainMessage({ serviceName, newListings, notificationConfig, jobKey });
+  }
+};
+
 export const config = {
   id: 'telegram',
   name: 'Telegram',
@@ -73,6 +135,12 @@ export const config = {
       type: 'chatId',
       label: 'Chat Id',
       description: 'The chat id to send messages to you.',
+    },
+    richMessage: {
+      type: 'boolean',
+      label: 'Send rich message',
+      description: 'When selected sends a rich message with image.',
+      value: false,
     },
   },
 };

--- a/lib/notification/adapter/telegram.js
+++ b/lib/notification/adapter/telegram.js
@@ -30,23 +30,27 @@ function isValidURL(url) {
 }
 
 const sendTelegramMessage = (token, chatId, message, isPhoto = false, photoUrl = '') => {
-  const url = isPhoto
-    ? `https://api.telegram.org/bot${token}/sendPhoto`
-    : `https://api.telegram.org/bot${token}/sendMessage`;
-  const body = isPhoto
-    ? JSON.stringify({
-        chat_id: chatId,
-        photo: photoUrl,
-        caption: message,
-        parse_mode: 'HTML',
-      })
-    : JSON.stringify({
-        chat_id: chatId,
-        text: message,
-        parse_mode: 'HTML',
-        disable_web_page_preview: !isPhoto,
-      });
+  let url = ''
+  let body = ''
 
+  if (isPhoto) {
+    url = `https://api.telegram.org/bot${token}/sendPhoto`;
+    body = JSON.stringify({
+      chat_id: chatId,
+      photo: photoUrl,
+      caption: message,
+      parse_mode: 'HTML',
+    });
+  } else {
+    url = `https://api.telegram.org/bot${token}/sendMessage`;
+    body = JSON.stringify({
+      chat_id: chatId,
+      text: message,
+      parse_mode: 'HTML',
+      disable_web_page_preview: !isPhoto,
+    });
+  }
+  
   /**
    * This is to not break the rate limit. It is to only send 1 message per second
    */

--- a/lib/provider/einsAImmobilien.js
+++ b/lib/provider/einsAImmobilien.js
@@ -28,6 +28,7 @@ const config = {
     rooms: '.tabelle .inner_object_data .data_boxes div:nth-child(2)',
     title: '.tabelle .inner_object_data .tabelle_inhalt_titel_black | removeNewline | trim',
     description: '.tabelle .inner_object_data .objekt_beschreibung | removeNewline | trim',
+    image: '.tabelle .inner_object_pic img@src',
   },
   normalize: normalize,
   filter: applyBlacklist,

--- a/lib/provider/immoscout.js
+++ b/lib/provider/immoscout.js
@@ -24,6 +24,8 @@ const config = {
     title: '.result-list-entry .result-list-entry__brand-title-container h2 | removeNewline | trim',
     link: '.result-list-entry .result-list-entry__brand-title-container@href',
     address: '.result-list-entry .result-list-entry__map-link',
+    image: '.result-list-entry .gallery-container .slick-list .gallery__image@src',
+    lazyImage: '.result-list-entry .gallery-container .gallery__image@data-lazy-src',
   },
   paginate: '#pager .align-right a@href',
   normalize: normalize,

--- a/lib/provider/kleinanzeigen.js
+++ b/lib/provider/kleinanzeigen.js
@@ -30,6 +30,7 @@ const config = {
         link: '.aditem-main .text-module-begin a@href | removeNewline | trim',
         description: '.aditem-main p:not(.text-module-end) | removeNewline | trim',
         address: '.aditem-main--top--left | trim | removeNewline',
+        image: '.aditem-image .imagebox img@src',
     },
     paginate: '#srchrslt-pagination .pagination-next@href',
     normalize: normalize,

--- a/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
+++ b/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
@@ -142,8 +142,9 @@ export default function NotificationAdapterMutator({
       return (
         <Form key={key}>
           {uiElement.type === 'boolean' ? (
-            <Switch
-              checked={uiElement.value || false}
+            <Form.Switch
+              checked={uiElement.checked || false}
+              label={uiElement.label}
               onChange={(checked) => {
                 setValue(selectedAdapter, uiElement, key, checked);
               }}


### PR DESCRIPTION
That PR updates the Telegram adapter and adds a rich message option with a photo.

<img width="720" src="https://github.com/user-attachments/assets/7505a856-d01d-4bf4-bf03-2e6d308db825">

It also updates a predefined example.

<table>
  <tr>
    <th>Plain message</th> 
    <th>Rich message</th>
  </tr>
  <tr>
    <td><img width="360" src="https://github.com/user-attachments/assets/134dd4a0-eaa7-4fde-ae04-8b7997ffca7e"></td> 
    <td><img width="360" src="https://github.com/user-attachments/assets/aefb1148-f2f2-4ace-9aae-71c8d217bd3d"></td> 
  </tr>
</table>

**Note:** the PR adds image parsing for immobilienscout24, kleinanzeigen, 1a-immobilienmarkt.