### PR TITLE
einsAImmobilien: get inner text only

### DIFF
--- a/lib/provider/einsAImmobilien.js
+++ b/lib/provider/einsAImmobilien.js
@@ -23,7 +23,7 @@ const config = {
   sortByDateParam: 'sort_type=newest',
   crawlFields: {
     id: '.inner_object_data input[name="marker_objekt_id"]@value | int',
-    price: '.tabelle .inner_object_data .single_data_price | removeNewline | trim',
+    price: '.tabelle .inner_object_data .single_data_price .innerText| removeNewline | trim',
     size: '.tabelle .inner_object_data .data_boxes div:nth-child(1)',
     rooms: '.tabelle .inner_object_data .data_boxes div:nth-child(2)',
     title: '.tabelle .inner_object_data .tabelle_inhalt_titel_black | removeNewline | trim',


### PR DESCRIPTION
As discussed in [102](https://github.com/orangecoding/fredy/issues/102)

This *should* only get the text of the diff. I tested it by changing my fredy instance and waited for the next job. No errors. I tried running the tests, but it only printed `  #einsAImmobilien testsuite()`and then did nothing for 10m.

As I said, I know next to nothing about js, so just because there isn't an error doesn't mean it positively works. 

If you feel the quality of this PR is poor just feel free to delete it.