### PR TITLE
Fix Puppeteer launch failure on ARM by using system-installed Chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ WORKDIR  /fredy
 
 COPY . /fredy
 
+RUN apt-get update && apt-get install -y chromium
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+  PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
 RUN yarn install
 
 RUN yarn global add pm2


### PR DESCRIPTION
**Description**
This PR fixes an issue where Puppeteer fails to launch on ARM-based systems due to an incompatible Chromium binary. The solution ensures Puppeteer uses a system-installed Chromium compatible with ARM.

**Context**
Fixes #121 

**Changes Made**
1. Added Chromium installation in the Dockerfile:
   ```dockerfile
   RUN apt-get update && apt-get install -y chromium
   ```
2. Set Puppeteer-specific environment variables to use system-installed version
   ```dockerfile
   ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
       PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
   ```