### PR TITLE
ImmoScout: Web paths with SEO optimization to mobile params

### DIFF
--- a/lib/services/immoscout/immoscout-web-translater.js
+++ b/lib/services/immoscout/immoscout-web-translater.js
@@ -79,6 +79,7 @@ const PARAM_NAME_MAP = {
   geocoordinates: 'geocoordinates',
   shape: 'shape',
   sorting: 'sorting',
+  newbuilding: 'newbuilding'
 };
 
 const EQUIPMENT_MAP = {
@@ -89,6 +90,7 @@ const EQUIPMENT_MAP = {
   garden: 'garden',
   guesttoilet: 'guestToilet',
   balcony: 'balcony',
+  handicappedaccessible: 'handicappedAccessible'
 };
 
 const REAL_ESTATE_TYPE = {
@@ -96,6 +98,29 @@ const REAL_ESTATE_TYPE = {
   'wohnung-mieten': 'apartmentrent',
   'wohnung-kaufen': 'apartmentbuy',
   'haus-kaufen': 'housebuy',
+};
+
+const WEB_PATH_TO_APARTMENT_EQUIPMENT_MAP = {
+  // Category "Balkon/Terrasse"
+  'wohnung-mit-balkon-mieten': { equipment: ['balcony'] },
+  'wohnung-mit-garten-mieten': { equipment: ['garden'] },
+  // Category "Wohnungstyp"
+  'souterrainwohnung-mieten': { apartmenttypes: ['halfbasement'] },
+  'erdgeschosswohnung-mieten': { apartmenttypes: ['groundfloor'] },
+  'hochparterrewohnung-mieten': { apartmenttypes: ['raisedgroundfloor'] },
+  'etagenwohnung-mieten': { apartmenttypes: ['apartment'] },
+  'loft-mieten': { apartmenttypes: ['loft'] },
+  'maisonette-mieten': { apartmenttypes: ['maisonette'] },
+  'terrassenwohnung-mieten': { apartmenttypes: ['terracedflat'] },
+  'penthouse-mieten': { apartmenttypes: ['penthouse'] },
+  'dachgeschosswohnung-mieten': { apartmenttypes: ['roofstorey'] },
+  // Category "Ausstattung"
+  'wohnung-mit-garage-mieten': { equipment: ['parking'] },
+  'wohnung-mit-einbaukueche-mieten': { equipment: ['builtinkitchen'] },
+  'wohnung-mit-keller-mieten': { equipment: ['cellar'] },
+  // Category "Merkmale"
+  'neubauwohnung-mieten': { newbuilding: true },
+  'barrierefreie-wohnung-mieten': { equipment: ['handicappedaccessible'] }
 };
 
 export function convertWebToMobile(webUrl) {
@@ -112,9 +137,17 @@ export function convertWebToMobile(webUrl) {
   }
 
   const realTypeKey = segments.at(-1);
-  const realType = REAL_ESTATE_TYPE[realTypeKey];
+  let realType = REAL_ESTATE_TYPE[realTypeKey];
+  let additionalParamsFromWebPath;
+
   if (!realType) {
-    throw new Error(`Real estate type not found: ${realTypeKey}`);
+    // Test for seo optimized apartment path (only used on the ImmoScout web app)
+    if (WEB_PATH_TO_APARTMENT_EQUIPMENT_MAP[realTypeKey]) {
+      additionalParamsFromWebPath = WEB_PATH_TO_APARTMENT_EQUIPMENT_MAP[realTypeKey];
+      realType = REAL_ESTATE_TYPE['wohnung-mieten'];
+    } else {
+      throw new Error(`Real estate type not found: ${realTypeKey}`);
+    }
   }
 
   if (segments.includes('shape')) {
@@ -132,6 +165,7 @@ export function convertWebToMobile(webUrl) {
     searchType: isRadius ? 'radius' : 'region',
     realestatetype: realType,
     ...(isRadius ? {} : { geocodes }),
+    ...additionalParamsFromWebPath
   };
 
   if (webParams.geocoordinates) {
@@ -141,7 +175,8 @@ export function convertWebToMobile(webUrl) {
   for (const [key, val] of Object.entries(webParams)) {
     if (key === 'equipment') {
       const items = [].concat(val).flatMap((v) => `${v}`.split(','));
-      mobileParams[PARAM_NAME_MAP[key]] = items.map((item) => EQUIPMENT_MAP[item.toLowerCase()]).filter(Boolean);
+      const currentEquipmentParams = mobileParams[PARAM_NAME_MAP[key]];
+      mobileParams[PARAM_NAME_MAP[key]] = [...currentEquipmentParams ?? [], ...items.map((item) => EQUIPMENT_MAP[item.toLowerCase()]).filter(Boolean)];
     } else {
       mobileParams[PARAM_NAME_MAP[key]] = val;
     }

--- a/test/services/immoscout/immoscout-web-translater.test.js
+++ b/test/services/immoscout/immoscout-web-translater.test.js
@@ -16,6 +16,16 @@ describe('#immoscout-mobile URL conversion', () => {
     expect(actualMobileUrl).to.equal(expectedMobileUrl);
   });
 
+  // Test URL conversion of web-only SEO path
+  it('should convert a SEO web path to the correct query params', () => {
+    const webUrl =
+      'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mit-balkon-mieten?equipment=garden';
+
+    const converted = convertWebToMobile(webUrl);
+    const queryParams = new URL(converted).searchParams;
+    expect(queryParams.get('equipment').split(',')).to.include.members(['garden', 'balcony']);
+  });
+
   // Test URL conversion with unsupported query parameters
   it('should remove unsupported query parameters', () => {
     const webUrl = 'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mieten?minimuminternetspeed=100000';


### PR DESCRIPTION
This PR adds the ability for the SEO optimized paths that the ImmoScout24 web app outputs to be converted to the usual query params that the mobile api uses.

These paths only appear when you use certain filters, and some of them supersede others. For example, most of the apartment type filters supersedes the balcony/garden filter, the latter is then represented as the usual query parameters. 

It also adds `newbuilding` to the allowed mobile params (for "Neubauwohnungen" filter"), and `handicappedaccessible` as an allowed equipment type (for "barrierefreie Wohnung" filter).

I tweaked the way equipment params are added to the mobileQuery variable to allow both sources of equipment types (web path conversion and the usual way via the actual params) to be merged.

Note that this only works for apartment renting for now. I assume the path structure is similar for houses and buying, but I haven't tested it. Maybe it would be better in the long run to write a function to build the web path segments, because they seem to follow a similar schema.