### PR TITLE
Remove leading commas from listings in Telegram messages

### DIFF
--- a/lib/notification/adapter/telegram.js
+++ b/lib/notification/adapter/telegram.js
@@ -22,16 +22,18 @@ export const send = ({ serviceName, newListings, notificationConfig, jobKey }) =
   const { token, chatId } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
   const job = getJob(jobKey);
   const jobName = job == null ? jobKey : job.name;
-  //we have to split messages into chunk, because otherwise messages are going to become too big and will fail
+  // we have to split messages into chunks, because otherwise messages are going to become too big and will fail
   const chunks = arrayChunks(newListings, MAX_ENTITIES_PER_CHUNK);
   const promises = chunks.map((chunk) => {
-    let message = `<i>${jobName}</i> (${serviceName}) found <b>${newListings.length}</b> new listings:\n\n`;
-    message += chunk.map(
+    const messageParagraphs = [];
+
+    messageParagraphs.push(`<i>${jobName}</i> (${serviceName}) found <b>${newListings.length}</b> new listings:`);
+    messageParagraphs.push(...chunk.map(
       (o) =>
         `<a href='${o.link}'><b>${shorten(o.title.replace(/\*/g, ''), 45).trim()}</b></a>\n` +
-        [o.address, o.price, o.size].join(' | ') +
-        '\n\n',
-    );
+        [o.address, o.price, o.size].join(' | ')
+    ));
+
     /**
      * This is to not break the rate limit. It is to only send 1 message per second
      */
@@ -41,7 +43,7 @@ export const send = ({ serviceName, newListings, notificationConfig, jobKey }) =
           method: 'post',
           body: JSON.stringify({
             chat_id: chatId,
-            text: message,
+            text: messageParagraphs.join('\n\n'),
             parse_mode: 'HTML',
             disable_web_page_preview: true,
           }),

--- a/ui/src/App.less
+++ b/ui/src/App.less
@@ -41,3 +41,7 @@ a:active {
   background-color: transparent;
   text-decoration: underline;
 }
+
+.semi-icon {
+  vertical-align: middle;
+}

--- a/ui/src/views/jobs/ProcessingTimes.jsx
+++ b/ui/src/views/jobs/ProcessingTimes.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {format} from '../../services/time/timeService';
-import {Banner, Descriptions} from '@douyinfe/semi-ui';
+import {Descriptions} from '@douyinfe/semi-ui';
 
 export default function ProcessingTimes({processingTimes = {}}) {
     if (Object.keys(processingTimes).length === 0) {

--- a/ui/src/views/jobs/mutation/components/provider/ProviderMutator.jsx
+++ b/ui/src/views/jobs/mutation/components/provider/ProviderMutator.jsx
@@ -101,7 +101,7 @@ export default function ProviderMutator({ onVisibilityChanged, visible = false, 
         description={
           <div>
             <p>
-              Currently, our Immoscout implementation does not drawing shapes on a map. Use a radius instead.
+              Currently, our Immoscout implementation does not support drawing shapes on a map. Use a radius instead.
             </p>
           </div>
         }


### PR DESCRIPTION
This MR includes:
* Remove comma prefixes in Telegram messages
* Icon alignment with text
* [Fixed an ESLint error](https://github.com/orangecoding/fredy/pull/142/files#diff-9ddbe1217b7598ed35e7a1d9d7d5f3f6eb10a4761008990d70a40f0da289caab)
* [Added a missing word to ImmoScout24 hint](https://github.com/orangecoding/fredy/pull/142/files#diff-9ddbe1217b7598ed35e7a1d9d7d5f3f6eb10a4761008990d70a40f0da289caab)

# Comma prefixes in Telegram messages

**The way Telegram message chunks were concatenated before lead to a leading comma for every subsequent listing after the first one found:**

<img width="300" alt="telegram-comma" src="https://github.com/user-attachments/assets/4a9e5966-1db0-4d6a-b054-aaa1d6c6ec8a" />

This is due to an array of strings being added to the message string directly:

https://github.com/orangecoding/fredy/blob/d89b0782378f52126855e9221389c48aedddf28e/lib/notification/adapter/telegram.js#L29-L34

I changed it to append to an array of strings, each acting as a paragraph, to be later concatenated using newlines.

# Icon alignment with text

As can be seen below, when setting all icon's `vertical-alignment` property to `middle`, they become perfectly aligned with the text, instead of being a little bit too high.

![icon-alignment](https://github.com/user-attachments/assets/2e358a1a-bba3-40fd-9b7c-b3157b044c35)
