### PR TITLE
Formatting and linting pre-commit hook

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/package.json
+++ b/package.json
@@ -3,19 +3,20 @@
   "version": "11.2.5",
   "description": "[F]ind [R]eal [E]states [d]amn eas[y].",
   "scripts": {
+    "prepare": "husky",
     "start": "node prod.js",
     "dev": "yarn && rm -rf ./ui/public/* && vite",
     "ui": "rm -rf ./ui/public/* && vite",
     "prod": "yarn && vite build --emptyOutDir",
-    "format": "prettier --write lib/**/*.js ui/src/**/*.jsx test/**/*.js *.js --single-quote --print-width 120",
+    "format": "prettier --write lib/**/*.js ui/src/**/*.jsx test/**/*.js *.js",
     "test": "mocha --loader=esmock --timeout 3000000 test/**/*.test.js",
-    "lint": "eslint ./index.js ./lib/**/*.js ./test/**/*.js ./ui/src/**/*.jsx"
+    "lint": "eslint index.js lib/**/*.js test/**/*.js ui/src/**/*.jsx --fix"
   },
   "type": "module",
   "lint-staged": {
-    "*.js": [
-      "eslint ./index.js ./lib/**/*.js ./test/**/*.js",
-      "prettier --single-quote --print-width 120 --write"
+    "*.{js,jsx}": [
+      "npm run lint",
+      "npm run format"
     ]
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "nanoid": "5.1.5",
     "node-fetch": "3.3.2",
     "node-mailjet": "6.0.8",
-    "p-throttle": "^7.0.0",
     "package-up": "^5.0.0",
     "puppeteer": "^24.14.0",
     "puppeteer-extra": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "type": "module",
   "lint-staged": {
     "*.{js,jsx}": [
-      "npm run lint",
-      "npm run format"
+      "yarn lint",
+      "yarn format"
     ]
   },
   "main": "index.js",
@@ -70,6 +70,7 @@
     "nanoid": "5.1.5",
     "node-fetch": "3.3.2",
     "node-mailjet": "6.0.8",
+    "p-throttle": "^7.0.0",
     "package-up": "^5.0.0",
     "puppeteer": "^24.14.0",
     "puppeteer-extra": "^3.3.6",


### PR DESCRIPTION
This MR aims to fix the pre-commit hook in place for formatting and linting which currently isn't automatically setup as a `pre-commit` hook and does not work when run manually.