### PR TITLE
Fix startup crash by catching and logging errors instead of exiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,15 +87,19 @@ const execute = () => {
           job.provider
             .filter((p) => providers.find((loaded) => loaded.metaInformation.id === p.id) != null)
             .forEach(async (prov) => {
-              const matchedProvider = providers.find((loaded) => loaded.metaInformation.id === prov.id);
-              matchedProvider.init(prov, job.blacklist);
-              await new FredyPipeline(
-                matchedProvider.config,
-                job.notificationAdapter,
-                prov.id,
-                job.id,
-                similarityCache,
-              ).execute();
+              try {
+                const matchedProvider = providers.find((loaded) => loaded.metaInformation.id === prov.id);
+                matchedProvider.init(prov, job.blacklist);
+                await new FredyPipeline(
+                  matchedProvider.config,
+                  job.notificationAdapter,
+                  prov.id,
+                  job.id,
+                  similarityCache,
+                ).execute();
+              } catch (error) {
+                logger.error(error);
+              }
             });
         });
     } else {


### PR DESCRIPTION
Relates to #244 and #245.

The application previously exited immediately when `matchedProvider.init(prov, job.blacklist)` threw an exception during startup, causing unreliable startups in certain environments. This change wraps the init logic in a try/catch that logs the error and allows the app to continue running.