### PR TITLE
Use EUR-symbol to match Map.jsx (see d43c5b3)

### DIFF
--- a/ui/src/views/dashboard/Dashboard.jsx
+++ b/ui/src/views/dashboard/Dashboard.jsx
@@ -136,7 +136,7 @@ export default function Dashboard() {
                 <KpiCard
                   title="Avg. Price"
                   color="purple"
-                  value={`${!kpis.avgPriceOfListings ? '---' : kpis.avgPriceOfListings} EUR`}
+                  value={`${!kpis.avgPriceOfListings ? '---' : kpis.avgPriceOfListings} €`}
                   icon={<IconNoteMoney />}
                   description="Avg. Price of listings"
                 />


### PR DESCRIPTION
Hello & thanks for this tool 🫶

I noticed this little UI mismatch, given that almost all other price-related labels use `€` already.

---

Side question: I also wondered whether displaying these prices in full Euros is best? Rounding to `T,H k€` seems to fit the domain better, unless it's about flat rentals.