### PR TITLE
add support for fulltext parameter for immoscout

### DIFF
--- a/lib/services/immoscout/immoscout-web-translator.js
+++ b/lib/services/immoscout/immoscout-web-translator.js
@@ -86,6 +86,7 @@ const PARAM_NAME_MAP = {
   shape: 'shape',
   sorting: 'sorting',
   newbuilding: 'newbuilding',
+  fulltext: 'fulltext',
 };
 
 const EQUIPMENT_MAP = {


### PR DESCRIPTION
The web client uses this parameter for the "Eigene Suchkriterien" textbox. It turns out that this parameter also exists for the mobile API.
I will note that I have only tested this with a single "Suchkriterium". The web client allows using multiple of those and I have not tested if this works correctly.