### PR TITLE
Feature/Kleinanzeigen addresses

### DIFF
--- a/lib/api/routes/userSettingsRoute.js
+++ b/lib/api/routes/userSettingsRoute.js
@@ -118,4 +118,25 @@ userSettingsRouter.post('/immoscout-details', async (req, res) => {
   }
 });
 
+userSettingsRouter.post('/kleinanzeigen-details', async (req, res) => {
+  const userId = req.session.currentUser;
+  const { kleinanzeigen_details } = req.body;
+
+  const globalSettings = await getSettings();
+  if (globalSettings.demoMode) {
+    res.statusCode = 403;
+    res.send({ error: 'In demo mode, it is not allowed to change settings.' });
+    return;
+  }
+
+  try {
+    upsertSettings({ kleinanzeigen_details: !!kleinanzeigen_details }, userId);
+    res.send({ success: true });
+  } catch (error) {
+    logger.error('Error updating kleinanzeigen details setting', error);
+    res.statusCode = 500;
+    res.send({ error: error.message });
+  }
+});
+
 export { userSettingsRouter };

--- a/lib/provider/kleinanzeigen.js
+++ b/lib/provider/kleinanzeigen.js
@@ -7,10 +7,12 @@ import { buildHash, isOneOf } from '../utils.js';
 import checkIfListingIsActive from '../services/listings/listingActiveTester.js';
 import Extractor from '../services/extractor/extractor.js';
 import logger from '../services/logger.js';
+import { getUserSettings } from '../services/storage/settingsStorage.js';
 import * as cheerio from 'cheerio';
 
 let appliedBlackList = [];
 let appliedBlacklistedDistricts = [];
+let currentUserId = null;
 
 function toAbsoluteLink(link) {
   if (!link) return null;
@@ -161,6 +163,16 @@ async function getListings(url) {
   const extractor = new Extractor();
   await extractor.execute(url, config.waitForSelector);
   const listings = extractor.parseResponseText(config.crawlContainer, config.crawlFields, url) || [];
+
+  const shouldFetchDetails = currentUserId ? !!getUserSettings(currentUserId).kleinanzeigen_details : false;
+
+  if (!shouldFetchDetails) {
+    return listings.map((listing) => ({
+      ...listing,
+      link: toAbsoluteLink(listing.link) || listing.link,
+    }));
+  }
+
   const enriched = [];
   for (const listing of listings) {
     enriched.push(await enrichListingFromDetails(listing));
@@ -213,5 +225,6 @@ export const init = (sourceConfig, blacklist, blacklistedDistricts) => {
   config.url = sourceConfig.url;
   appliedBlacklistedDistricts = blacklistedDistricts || [];
   appliedBlackList = blacklist || [];
+  currentUserId = sourceConfig.userId || null;
 };
 export { config };

--- a/ui/src/services/state/store.js
+++ b/ui/src/services/state/store.js
@@ -318,6 +318,20 @@ export const useFredyState = create(
               throw Exception;
             }
           },
+          async setKleinanzeigenDetails(enabled) {
+            try {
+              await xhrPost('/api/user/settings/kleinanzeigen-details', { kleinanzeigen_details: enabled });
+              set((state) => ({
+                userSettings: {
+                  ...state.userSettings,
+                  settings: { ...state.userSettings.settings, kleinanzeigen_details: enabled },
+                },
+              }));
+            } catch (Exception) {
+              console.error('Error while trying to update kleinanzeigen details setting. Error:', Exception);
+              throw Exception;
+            }
+          },
         },
       };
 

--- a/ui/src/views/generalSettings/GeneralSettings.jsx
+++ b/ui/src/views/generalSettings/GeneralSettings.jsx
@@ -73,6 +73,7 @@ const GeneralSettings = function GeneralSettings() {
   // User settings state
   const homeAddress = useSelector((state) => state.userSettings.settings.home_address);
   const immoscoutDetails = useSelector((state) => state.userSettings.settings.immoscout_details);
+  const kleinanzeigenDetails = useSelector((state) => state.userSettings.settings.kleinanzeigen_details);
   const [address, setAddress] = useState(homeAddress?.address || '');
   const [coords, setCoords] = useState(homeAddress?.coords || null);
   const saving = useIsLoading(actions.userSettings.setHomeAddress);
@@ -462,6 +463,32 @@ const GeneralSettings = function GeneralSettings() {
                       }}
                     />
                     <Text>Fetch detailed ImmoScout listings</Text>
+                  </div>
+                </SegmentPart>
+
+                <SegmentPart
+                  name="Kleinanzeigen Details"
+                  helpText="Fetch the individual listing page for each Kleinanzeigen result to extract a more detailed address and description. Makes an extra request per listing."
+                >
+                  <Banner
+                    type="warning"
+                    description="Enabling this significantly increases requests to Kleinanzeigen, raising the chance of rate limiting or blocking. Use at your own risk."
+                    closeIcon={null}
+                    style={{ marginBottom: 12 }}
+                  />
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <Switch
+                      checked={!!kleinanzeigenDetails}
+                      onChange={async (checked) => {
+                        try {
+                          await actions.userSettings.setKleinanzeigenDetails(checked);
+                          Toast.success('Kleinanzeigen details setting updated.');
+                        } catch {
+                          Toast.error('Failed to update setting.');
+                        }
+                      }}
+                    />
+                    <Text>Fetch detailed Kleinanzeigen listings</Text>
                   </div>
                 </SegmentPart>
 

--- a/ui/src/views/userSettings/UserSettings.jsx
+++ b/ui/src/views/userSettings/UserSettings.jsx
@@ -15,6 +15,7 @@ const UserSettings = () => {
   const actions = useActions();
   const homeAddress = useSelector((state) => state.userSettings.settings.home_address);
   const immoscoutDetails = useSelector((state) => state.userSettings.settings.immoscout_details);
+  const kleinanzeigenDetails = useSelector((state) => state.userSettings.settings.kleinanzeigen_details);
   const [address, setAddress] = useState(homeAddress?.address || '');
   const [coords, setCoords] = useState(homeAddress?.coords || null);
   const saving = useIsLoading(actions.userSettings.setHomeAddress);
@@ -109,6 +110,33 @@ const UserSettings = () => {
             }}
           />
           <span>Fetch detailed ImmoScout listings</span>
+        </div>
+      </SegmentPart>
+      <Divider />
+      <SegmentPart
+        name="Kleinanzeigen Details"
+        Icon={IconSearch}
+        helpText="When enabled, Fredy will fetch the individual listing page for each Kleinanzeigen result to extract a more detailed address and description. This makes an extra request per listing."
+      >
+        <Banner
+          type="warning"
+          description="Enabling this feature significantly increases the number of requests to Kleinanzeigen. This raises the likelihood of being detected and rate-limited or blocked. Use at your own risk."
+          closeIcon={null}
+          style={{ marginBottom: '12px', maxWidth: '600px' }}
+        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <Switch
+            checked={!!kleinanzeigenDetails}
+            onChange={async (checked) => {
+              try {
+                await actions.userSettings.setKleinanzeigenDetails(checked);
+                Toast.success('Kleinanzeigen details setting updated.');
+              } catch {
+                Toast.error('Failed to update setting.');
+              }
+            }}
+          />
+          <span>Fetch detailed Kleinanzeigen listings</span>
         </div>
       </SegmentPart>
       <Divider />


### PR DESCRIPTION
It was bugging me that Kleinanzeigen listings only provided the postal code and not the full address.
As a result, they didn't show up on the map correctly.

This PR provides a toggle similar to Immoscout Details that allows the scraping of individual listings so as to provide a full address and description.