### PR TITLE
Add toggle for sending telegram message as plain text message

### DIFF
--- a/lib/notification/adapter/telegram.js
+++ b/lib/notification/adapter/telegram.js
@@ -106,6 +106,32 @@ function buildText(jobName, serviceName, o) {
 }
 
 /**
+ * Build a plain text Telegram photo caption (max 4096 characters).
+ * @param {string} jobName
+ * @param {string} serviceName
+ * @param {Object} o - Listing object
+ * @returns {string}
+ */
+function buildCaptionPlain(jobName, serviceName, o) {
+  const title = shorten((o.title || '').replace(/\*/g, ''), 90);
+  const meta = [o.address, o.price, o.size].filter(Boolean).join(' | ');
+  return `${jobName} (${serviceName})\n${title}\n${meta}\n\n${o.link || ''}`.slice(0, 4096);
+}
+
+/**
+ * Build a plain text Telegram message.
+ * @param {string} jobName
+ * @param {string} serviceName
+ * @param {Object} o - Listing object
+ * @returns {string}
+ */
+function buildTextPlain(jobName, serviceName, o) {
+  const title = shorten((o.title || '').replace(/\*/g, ''), 90);
+  const meta = [o.address, o.price, o.size].filter(Boolean).join(' | ');
+  return `${jobName} (${serviceName})\n${title}\n${o.link || ''}\n${meta}`;
+}
+
+/**
  * Send new listings to Telegram.
  * - Respects per-chat Telegram rate limits using a lightweight throttle cache.
  * - Falls back to sendMessage when sendPhoto fails or image is missing.
@@ -122,7 +148,7 @@ export const send = ({ serviceName, newListings = [], notificationConfig, jobKey
   if (!adapterCfg || !adapterCfg.fields) {
     throw new Error(`Telegram adapter configuration missing for job '${jobKey || ''}'`);
   }
-  const { token, chatId, messageThreadId } = adapterCfg.fields;
+  const { token, chatId, messageThreadId, plainText } = adapterCfg.fields;
   if (!token || !chatId) {
     throw new Error("Telegram 'token' and 'chatId' must be provided in notification config");
   }
@@ -163,8 +189,8 @@ export const send = ({ serviceName, newListings = [], notificationConfig, jobKey
     const img = normalizeImageUrl(o.image);
     const textPayload = {
       chat_id: chatId,
-      text: buildText(jobName, serviceName, o),
-      parse_mode: 'HTML',
+      text: plainText ? buildTextPlain(jobName, serviceName, o) : buildText(jobName, serviceName, o),
+      ...(plainText ? {} : { parse_mode: 'HTML' }),
       disable_web_page_preview: true,
       ...(message_thread_id ? { message_thread_id } : {}),
     };
@@ -178,8 +204,8 @@ export const send = ({ serviceName, newListings = [], notificationConfig, jobKey
     return await throttledCall('sendPhoto', {
       chat_id: chatId,
       photo: img,
-      caption: buildCaption(jobName, serviceName, o),
-      parse_mode: 'HTML',
+      caption: plainText ? buildCaptionPlain(jobName, serviceName, o) : buildCaption(jobName, serviceName, o),
+      ...(plainText ? {} : { parse_mode: 'HTML' }),
       ...(message_thread_id ? { message_thread_id } : {}),
     }).catch(async (e) => {
       logger.error(`Error sending photo to Telegram and use a fallback: ${e.message}`);
@@ -219,6 +245,12 @@ export const config = {
       label: 'Message Thread Id (optional)',
       description:
         'Optional: The topic/thread id within a supergroup to post into (Telegram message_thread_id). Provide a positive integer.',
+    },
+    plainText: {
+      type: 'boolean',
+      optional: true,
+      label: 'Send as plain text',
+      description: 'Send messages as plain text instead of HTML formatted.',
     },
   },
 };

--- a/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
+++ b/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
@@ -156,14 +156,21 @@ export default function NotificationAdapterMutator({
       return (
         <Form key={key}>
           {uiElement.type === 'boolean' ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-              <Switch
-                checked={uiElement.value || false}
-                onChange={(checked) => {
-                  setValue(selectedAdapter, uiElement, key, checked);
-                }}
-              />
-              {uiElement.label}
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+                <Switch
+                  checked={uiElement.value || false}
+                  onChange={(checked) => {
+                    setValue(selectedAdapter, uiElement, key, checked);
+                  }}
+                />
+                {uiElement.label}
+              </div>
+              {uiElement.description && (
+                <div className="semi-form-field-extra" style={{ marginTop: '4px' }}>
+                  {uiElement.description}
+                </div>
+              )}
             </div>
           ) : (
             <Form.Input


### PR DESCRIPTION
Hi,

first, thanks for creating this service and making it open source - really useful 🙏 

This PR adds a toggle to the Telegram Notification Adapter to allow sending the messages in plain text instead of HTML. I personally prefer this, because I don't have to click again to open the link, see screenshot below. Also, the images are still rendered, because telegram generates a preview of the listing based on the link on the client.

<img width="409" height="241" alt="SCR-20260415-tuzz" src="https://github.com/user-attachments/assets/f994860a-5e72-4ca0-8502-89507c4f941f" />

For transparency, I have used Claude Code to add those changes, because I am not that familiar with JS.

Rendered toggle configuration in the adapter configuration:
<img width="779" height="240" alt="SCR-20260415-tqti" src="https://github.com/user-attachments/assets/a9e643a7-f675-41ee-bef4-22f1ce4a8794" />

<table>
<tr>
 <td>HTML Version:
 <td>Plain Text Version
<tr>
 <td><img width="461" height="278" alt="SCR-20260415-trqb" src="https://github.com/user-attachments/assets/06a742f6-fcc0-40ba-8eaf-6ead8763e83d" />
 <td><img width="559" height="313" alt="SCR-20260415-trnl" src="https://github.com/user-attachments/assets/deba0b28-8de6-4ded-9ad0-2ef622a68598" />
</table>






