### PR TITLE
change average price to median price on the dashboard

### DIFF
--- a/lib/api/routes/dashboardRouter.js
+++ b/lib/api/routes/dashboardRouter.js
@@ -37,7 +37,7 @@ dashboardRouter.get('/', async (req, res) => {
   const totalJobs = jobs.length;
   const totalListings = jobs.reduce((sum, j) => sum + (j.numberOfFoundListings || 0), 0);
   const jobIds = jobs.map((j) => j.id);
-  const { numberOfActiveListings, avgPriceOfListings } = getListingsKpisForJobIds(jobIds);
+  const { numberOfActiveListings, medianPriceOfListings } = getListingsKpisForJobIds(jobIds);
   // Build Pie data in a simple shape the frontend can consume directly
   // Shape: { labels: string[], values: number[] } with values as percentages
   const providerPieRaw = getProviderDistributionForJobIds(jobIds);
@@ -63,7 +63,7 @@ dashboardRouter.get('/', async (req, res) => {
       totalJobs,
       totalListings,
       numberOfActiveListings,
-      avgPriceOfListings,
+      medianPriceOfListings,
     },
     pie: providerPie,
   };

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -29,33 +29,46 @@ export const getKnownListingHashesForJobAndProvider = (jobId, providerId) => {
  * Compute KPI aggregates for a given set of job IDs from the listings table.
  *
  * - numberOfActiveListings: count of listings where is_active = 1
- * - avgPriceOfListings: average of numeric price, rounded to nearest integer
+ * - medianPriceOfListings: median of numeric price, rounded to nearest integer
  *
  * When no jobIds are provided, returns zeros.
  *
  * @param {string[]} jobIds
- * @returns {{ numberOfActiveListings: number, avgPriceOfListings: number }}
+ * @returns {{ numberOfActiveListings: number, medianPriceOfListings: number }}
  */
 export const getListingsKpisForJobIds = (jobIds = []) => {
   if (!Array.isArray(jobIds) || jobIds.length === 0) {
-    return { numberOfActiveListings: 0, avgPriceOfListings: 0 };
+    return { numberOfActiveListings: 0, medianPriceOfListings: 0 };
   }
 
   const placeholders = jobIds.map(() => '?').join(',');
-  const row =
-    SqliteConnection.query(
-      `SELECT
-          SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS activeCount,
-          AVG(price) AS avgPrice
-       FROM listings
-       WHERE job_id IN (${placeholders})
-         AND manually_deleted = 0`,
-      jobIds,
-    )[0] || {};
+  const rows = SqliteConnection.query(
+    `SELECT is_active, price
+        FROM listings
+        WHERE job_id IN (${placeholders})
+          AND manually_deleted = 0`,
+    jobIds,
+  );
+
+  let activeCount = 0;
+  const prices = [];
+
+  for (const row of rows) {
+    if (row.is_active === 1) activeCount++;
+    if (row.price !== null) prices.push(row.price);
+  }
+
+  let medianPrice = 0;
+  if (prices.length > 0) {
+    prices.sort((a, b) => a - b);
+    const mid = Math.floor(prices.length / 2);
+
+    medianPrice = prices.length % 2 !== 0 ? prices[mid] : (prices[mid - 1] + prices[mid]) / 2;
+  }
 
   return {
-    numberOfActiveListings: Number(row.activeCount || 0),
-    avgPriceOfListings: row?.avgPrice == null ? 0 : Math.round(Number(row.avgPrice)),
+    numberOfActiveListings: activeCount,
+    medianPriceOfListings: medianPrice,
   };
 };
 

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -42,7 +42,33 @@ export const getListingsKpisForJobIds = (jobIds = []) => {
   }
 
   const placeholders = jobIds.map(() => '?').join(',');
-  const rows = SqliteConnection.query(
+const rows = SqliteConnection.query(
+  `SELECT
+     SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS active_count,
+     price
+   FROM listings
+   WHERE job_id IN (${placeholders})
+     AND manually_deleted = 0`,
+  jobIds,
+);
+
+const activeCount = rows[0]?.active_count ?? 0;
+
+const prices = rows
+  .map(r => r.price)
+  .filter(p => p !== null)
+  .sort((a, b) => a - b);
+
+let medianPrice = 0;
+if (prices.length > 0) {
+  const mid = Math.floor(prices.length / 2);
+  medianPrice = prices.length % 2 !== 0 ? prices[mid] : (prices[mid - 1] + prices[mid]) / 2;
+}
+
+return {
+  numberOfActiveListings: activeCount,
+  medianPriceOfListings: medianPrice,
+};
     `SELECT is_active, price
         FROM listings
         WHERE job_id IN (${placeholders})

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -59,7 +59,7 @@ export const getListingsKpisForJobIds = (jobIds = []) => {
   const prices = rows
     .map((r) => r.price)
     .filter((p) => p !== null)
-    .toSorted((a, b) => a - b);
+    .sort((a, b) => a - b);
 
   let medianPrice = 0;
   if (prices.length > 0) {

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -48,7 +48,9 @@ export const getListingsKpisForJobIds = (jobIds = []) => {
       price
     FROM listings
     WHERE job_id IN (${placeholders})
-      AND manually_deleted = 0`,
+      AND manually_deleted = 0
+    GROUP BY
+      price`,
     jobIds,
   );
 
@@ -57,7 +59,7 @@ export const getListingsKpisForJobIds = (jobIds = []) => {
   const prices = rows
     .map((r) => r.price)
     .filter((p) => p !== null)
-    .sort((a, b) => a - b);
+    .toSorted((a, b) => a - b);
 
   let medianPrice = 0;
   if (prices.length > 0) {

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -42,53 +42,26 @@ export const getListingsKpisForJobIds = (jobIds = []) => {
   }
 
   const placeholders = jobIds.map(() => '?').join(',');
-const rows = SqliteConnection.query(
-  `SELECT
-     SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS active_count,
-     price
-   FROM listings
-   WHERE job_id IN (${placeholders})
-     AND manually_deleted = 0`,
-  jobIds,
-);
-
-const activeCount = rows[0]?.active_count ?? 0;
-
-const prices = rows
-  .map(r => r.price)
-  .filter(p => p !== null)
-  .sort((a, b) => a - b);
-
-let medianPrice = 0;
-if (prices.length > 0) {
-  const mid = Math.floor(prices.length / 2);
-  medianPrice = prices.length % 2 !== 0 ? prices[mid] : (prices[mid - 1] + prices[mid]) / 2;
-}
-
-return {
-  numberOfActiveListings: activeCount,
-  medianPriceOfListings: medianPrice,
-};
-    `SELECT is_active, price
-        FROM listings
-        WHERE job_id IN (${placeholders})
-          AND manually_deleted = 0`,
+  const rows = SqliteConnection.query(
+    `SELECT
+      SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS active_count,
+      price
+    FROM listings
+    WHERE job_id IN (${placeholders})
+      AND manually_deleted = 0`,
     jobIds,
   );
 
-  let activeCount = 0;
-  const prices = [];
+  const activeCount = rows[0]?.active_count ?? 0;
 
-  for (const row of rows) {
-    if (row.is_active === 1) activeCount++;
-    if (row.price !== null) prices.push(row.price);
-  }
+  const prices = rows
+    .map((r) => r.price)
+    .filter((p) => p !== null)
+    .sort((a, b) => a - b);
 
   let medianPrice = 0;
   if (prices.length > 0) {
-    prices.sort((a, b) => a - b);
     const mid = Math.floor(prices.length / 2);
-
     medianPrice = prices.length % 2 !== 0 ? prices[mid] : (prices[mid - 1] + prices[mid]) / 2;
   }
 

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -44,13 +44,13 @@ export const getListingsKpisForJobIds = (jobIds = []) => {
   const placeholders = jobIds.map(() => '?').join(',');
   const rows = SqliteConnection.query(
     `SELECT
-      SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS active_count,
+      SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) OVER() AS active_count,
       price
     FROM listings
     WHERE job_id IN (${placeholders})
       AND manually_deleted = 0
     GROUP BY
-      price`,
+      id`,
     jobIds,
   );
 

--- a/ui/src/views/dashboard/Dashboard.jsx
+++ b/ui/src/views/dashboard/Dashboard.jsx
@@ -127,18 +127,18 @@ export default function Dashboard() {
         </Col>
         <Col xs={24} sm={12} md={12} lg={6} xl={6}>
           <KpiCard
-            title="Avg. Price"
+            title="Median Price"
             color="purple"
             value={`${
-              !kpis.avgPriceOfListings
+              !kpis.medianPriceOfListings
                 ? '---'
                 : new Intl.NumberFormat('de-DE', {
                     style: 'currency',
                     currency: 'EUR',
-                  }).format(kpis.avgPriceOfListings)
+                  }).format(kpis.medianPriceOfListings)
             }`}
             icon={<IconNoteMoney />}
-            description="Avg. Price of listings"
+            description="Median Price of listings"
           />
         </Col>
       </Row>


### PR DESCRIPTION
Shows the median price instead of the average on the dashboard. This is more resilient to high priced or irregular listings.
For example, I've encountered a listing from someone who was searching, not offering, a flat. They set an imaginary price of 123456€ which impacted the average price significantly, the average price on my dashboard is now ~7k, whereas the median price is around 500€, which is far more accurate. I could manually remove it, but the problem that other flats which are too high priced, that somehow found their way into my search query, still persists.