### PR TITLE
fix: persist scheduler lastRun so dashboard shows last/next search

### DIFF
--- a/lib/services/jobs/jobExecutionService.js
+++ b/lib/services/jobs/jobExecutionService.js
@@ -8,6 +8,7 @@ import { bus } from '../events/event-bus.js';
 import * as jobStorage from '../storage/jobStorage.js';
 import * as userStorage from '../storage/userStorage.js';
 import { getUser } from '../storage/userStorage.js';
+import { upsertSettings } from '../storage/settingsStorage.js';
 import { duringWorkingHoursOrNotSet } from '../../utils.js';
 import FredyPipelineExecutioner from '../../FredyPipelineExecutioner.js';
 import * as similarityCache from '../similarity-check/similarityCache.js';
@@ -104,6 +105,7 @@ export function initJobExecutionService({ providers, settings, intervalMs }) {
       return;
     }
     settings.lastRun = now;
+    upsertSettings({ lastRun: now });
     const jobs = jobStorage
       .getJobs()
       .filter((job) => job.enabled)


### PR DESCRIPTION
## Summary

- The dashboard's **Last Search** and **Next Search** widgets are stuck on empty even when the scheduler is firing correctly.
- Root cause: `settings.lastRun` is only mutated on the in-memory settings object held by `initJobExecutionService`. Any subsequent `upsertSettings()` call (e.g. dismissing the news modal, which writes `news_hash`) calls `refreshSettingsCache()`, which reassigns the module-level `cachedSettingsConfig` to a fresh DB read. From that moment on, the scheduler keeps mutating its old reference, while the dashboard endpoint reads from the new cache that never sees `lastRun`.
- Fix: persist `lastRun` via `upsertSettings({ lastRun: now })` after each scheduler tick. The value now survives cache refreshes (and process restarts as a side benefit).

## How it manifests

1. Fresh start, no news dismissed → dashboard shows the timestamp briefly after the first tick.
2. User dismisses the news modal → `news_hash` upsert refreshes the cache → dashboard goes blank and stays blank, even though the scheduler keeps creating listings.

## Change

```diff
 settings.lastRun = now;
+upsertSettings({ lastRun: now });
```

Single file touched: `lib/services/jobs/jobExecutionService.js` (+ one `upsertSettings` import).

## Test plan

- [x] Reproduce empty `Last Search` / `Next Search` on a running instance with a `news_hash` already persisted.
- [x] Apply the patch and restart; verify `lastRun` row appears in the `settings` table after the first scheduler tick.
- [x] Verify dashboard endpoint returns non-null `lastRun` and `nextRun = lastRun + interval*60000`.
- [x] Verify the value survives a container restart.