### PR TITLE
fix: Sort direction toggle not working in listings overview

### DIFF
--- a/ui/src/components/listings/ListingsOverview.jsx
+++ b/ui/src/components/listings/ListingsOverview.jsx
@@ -197,7 +197,7 @@ const ListingsOverview = () => {
 
         <Button
           icon={sortDir === 'asc' ? <IconArrowUp /> : <IconArrowDown />}
-          onClick={() => setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+          onClick={() => setSortDir(sortDir === 'asc' ? 'desc' : 'asc')}
           title={sortDir === 'asc' ? 'Ascending' : 'Descending'}
         />
 


### PR DESCRIPTION
### Description
`setSortDir` reads `sortDir` directly inside the click handler, capturing a stale value from the render that created the handler. Rapid clicks or batched updates can drop or invert toggles.

### Steps to Reproduce
1. Click the sort toggle button in the listings overview twice.
2. Observe that the actual sort direction only changes once.

### Expected
Each click toggles `asc` ↔ `desc` based on the latest state.

### Actual
Toggle is computed from a stale closure value; updates can be lost.
