### PR TITLE
fixing filtering of lists

### DIFF
--- a/lib/FredyPipelineExecutioner.js
+++ b/lib/FredyPipelineExecutioner.js
@@ -7,7 +7,7 @@ import { NoNewListingsWarning } from './errors.js';
 import {
   storeListings,
   getKnownListingHashesForJobAndProvider,
-  deleteListingsById,
+  deleteListingsByHash,
 } from './services/storage/listingsStorage.js';
 import { getJob } from './services/storage/jobStorage.js';
 import * as notify from './notification/notify.js';
@@ -176,7 +176,7 @@ class FredyPipelineExecutioner {
     });
 
     if (toDeleteListingByIds.length > 0) {
-      deleteListingsById(toDeleteListingByIds);
+      deleteListingsByHash(toDeleteListingByIds);
     }
 
     return keptListings;
@@ -210,7 +210,7 @@ class FredyPipelineExecutioner {
     });
 
     if (toDeleteListingByIds.length > 0) {
-      deleteListingsById(toDeleteListingByIds);
+      deleteListingsByHash(toDeleteListingByIds);
     }
 
     return keptListings;
@@ -390,7 +390,7 @@ class FredyPipelineExecutioner {
     });
 
     if (filteredIds.length > 0) {
-      deleteListingsById(filteredIds);
+      deleteListingsByHash(filteredIds);
     }
 
     return keptListings;

--- a/lib/FredyPipelineExecutioner.js
+++ b/lib/FredyPipelineExecutioner.js
@@ -5,9 +5,10 @@
 
 import { NoNewListingsWarning } from './errors.js';
 import {
-  storeListings,
+  deleteListingsById,
   getKnownListingHashesForJobAndProvider,
-  deleteListingsByHash,
+  storeListings,
+  updateListingDistance,
 } from './services/storage/listingsStorage.js';
 import { getJob } from './services/storage/jobStorage.js';
 import * as notify from './notification/notify.js';
@@ -16,8 +17,7 @@ import urlModifier from './services/queryStringMutator.js';
 import logger from './services/logger.js';
 import { geocodeAddress } from './services/geocoding/geoCodingService.js';
 import { distanceMeters } from './services/listings/distanceCalculator.js';
-import { getUserSettings, getSettings } from './services/storage/settingsStorage.js';
-import { updateListingDistance } from './services/storage/listingsStorage.js';
+import { getSettings, getUserSettings } from './services/storage/settingsStorage.js';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import { formatListing } from './utils/formatListing.js';
 
@@ -97,9 +97,9 @@ class FredyPipelineExecutioner {
   }
 
   /**
-   * Optionally enrich new listings with data from their detail pages.
+   * Optionally, enrich new listings with data from their detail pages.
    * Only called when the provider config defines a `fetchDetails` function.
-   * Runs all fetches in parallel. Each individual fetch must handle its own errors
+   * Runs all fetches in parallel. Each fetch must handle its own errors
    * and always resolve (never reject) to avoid aborting other listings.
    *
    * @param {Listing[]} newListings New listings to enrich.
@@ -132,7 +132,7 @@ class FredyPipelineExecutioner {
     for (const listing of newListings) {
       if (listing.address) {
         const coords = await geocodeAddress(listing.address);
-        if (coords) {
+        if (coords && coords.lat !== -1 && coords.lng !== -1) {
           listing.latitude = coords.lat;
           listing.longitude = coords.lng;
         }
@@ -176,7 +176,7 @@ class FredyPipelineExecutioner {
     });
 
     if (toDeleteListingByIds.length > 0) {
-      deleteListingsByHash(toDeleteListingByIds);
+      deleteListingsById(toDeleteListingByIds);
     }
 
     return keptListings;
@@ -210,7 +210,7 @@ class FredyPipelineExecutioner {
     });
 
     if (toDeleteListingByIds.length > 0) {
-      deleteListingsByHash(toDeleteListingByIds);
+      deleteListingsById(toDeleteListingByIds);
     }
 
     return keptListings;
@@ -264,15 +264,15 @@ class FredyPipelineExecutioner {
     const requiredKeys = this._providerConfig.requiredFieldNames;
     const requireValues = ['id', 'link', 'title'];
 
-    const filteredListings = listings
-      // this should never filter some listings out, because the normalize function should always extract all fields.
-      .filter((item) => requiredKeys.every((key) => key in item))
-      // TODO: move blacklist filter to this file, so it will handle for all providers in same way.
-      .filter(this._providerConfig.filter)
-      // filter out listings that are missing required fields
-      .filter((item) => requireValues.every((key) => item[key] != null));
-
-    return filteredListings;
+    return (
+      listings
+        // this should never filter some listings out, because the normalize function should always extract all fields.
+        .filter((item) => requiredKeys.every((key) => key in item))
+        // TODO: move blacklist filter to this file, so it will handle for all providers in same way.
+        .filter(this._providerConfig.filter)
+        // filter out listings that are missing required fields
+        .filter((item) => requireValues.every((key) => item[key] != null))
+    );
   }
 
   /**
@@ -390,7 +390,7 @@ class FredyPipelineExecutioner {
     });
 
     if (filteredIds.length > 0) {
-      deleteListingsByHash(filteredIds);
+      deleteListingsById(filteredIds);
     }
 
     return keptListings;

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -417,9 +417,10 @@ export const deleteListingsByJobId = (jobId, hardDelete = false) => {
 };
 
 /**
- * Delete listings by a list of listing IDs.
+ * Delete listings by a list of listing IDs (the nanoid primary key stored in the `id` column).
+ * Used by API routes that receive row IDs from the client.
  *
- * @param {string[]} ids - Array of listing IDs to delete.
+ * @param {string[]} ids - Array of DB row IDs to delete.
  * @param {boolean} [hardDelete=false] - Whether to hard delete from DB or just mark as deleted.
  * @returns {any} The result from SqliteConnection.execute.
  */
@@ -438,6 +439,33 @@ export const deleteListingsById = (ids, hardDelete = false) => {
      SET manually_deleted = 1
      WHERE id IN (${placeholders})`,
     ids,
+  );
+};
+
+/**
+ * Delete listings by a list of provider listing hashes (the `hash` column, which stores the
+ * provider-assigned listing ID). Used by the pipeline filter steps which only have access to
+ * the provider-side ID, not the nanoid row ID assigned at insert time.
+ *
+ * @param {string[]} hashes - Array of provider listing IDs (stored in the `hash` column).
+ * @param {boolean} [hardDelete=false] - Whether to hard delete from DB or just mark as deleted.
+ * @returns {any} The result from SqliteConnection.execute.
+ */
+export const deleteListingsByHash = (hashes, hardDelete = false) => {
+  if (!Array.isArray(hashes) || hashes.length === 0) return;
+  const placeholders = hashes.map(() => '?').join(',');
+  if (hardDelete) {
+    return SqliteConnection.execute(
+      `DELETE FROM listings
+       WHERE hash IN (${placeholders})`,
+      hashes,
+    );
+  }
+  return SqliteConnection.execute(
+    `UPDATE listings
+     SET manually_deleted = 1
+     WHERE hash IN (${placeholders})`,
+    hashes,
   );
 };
 

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -214,6 +214,8 @@ export const storeListings = (jobId, providerId, listings) => {
         longitude: item.longitude || null,
       };
       stmt.run(params);
+      // Propagate the DB primary key back so downstream pipeline steps use the correct id
+      item.id = params.id;
     }
   });
 
@@ -439,33 +441,6 @@ export const deleteListingsById = (ids, hardDelete = false) => {
      SET manually_deleted = 1
      WHERE id IN (${placeholders})`,
     ids,
-  );
-};
-
-/**
- * Delete listings by a list of provider listing hashes (the `hash` column, which stores the
- * provider-assigned listing ID). Used by the pipeline filter steps which only have access to
- * the provider-side ID, not the nanoid row ID assigned at insert time.
- *
- * @param {string[]} hashes - Array of provider listing IDs (stored in the `hash` column).
- * @param {boolean} [hardDelete=false] - Whether to hard delete from DB or just mark as deleted.
- * @returns {any} The result from SqliteConnection.execute.
- */
-export const deleteListingsByHash = (hashes, hardDelete = false) => {
-  if (!Array.isArray(hashes) || hashes.length === 0) return;
-  const placeholders = hashes.map(() => '?').join(',');
-  if (hardDelete) {
-    return SqliteConnection.execute(
-      `DELETE FROM listings
-       WHERE hash IN (${placeholders})`,
-      hashes,
-    );
-  }
-  return SqliteConnection.execute(
-    `UPDATE listings
-     SET manually_deleted = 1
-     WHERE hash IN (${placeholders})`,
-    hashes,
   );
 };
 

--- a/test/mocks/mockStore.js
+++ b/test/mocks/mockStore.js
@@ -32,4 +32,7 @@ export const deletedIds = [];
 export const deleteListingsById = (ids) => {
   deletedIds.push(...ids);
 };
+export const deleteListingsByHash = (hashes) => {
+  deletedIds.push(...hashes);
+};
 /* eslint-enable no-unused-vars */


### PR DESCRIPTION

Problem...
In storeListings, each listing row is saved with two distinct identifiers:
  - id = a fresh nanoid() (the DB primary key)
  - hash = item.id (the provider-assigned listing ID, e.g. "12345" from Kleinanzeigen)
  
  After _save, the listing objects in memory still carry the provider ID in listing.id. The three post-save filter methods (_filterBySimilarListings, _filterBySpecs, _filterByArea) all collected those values and passed them to
  deleteListingsById, which ran:

  UPDATE listings SET manually_deleted = 1 WHERE id IN (?)

  The id column holds nanoids, so the provider IDs never matched, the soft-delete was a no-op and filtered listings remained visible.


