### PR TITLE
added redirect after login

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -11,7 +11,7 @@ import GeneralSettings from './views/generalSettings/GeneralSettings';
 import JobMutation from './views/jobs/mutation/JobMutation';
 import UserMutator from './views/user/mutation/UserMutator';
 import { useActions, useSelector } from './services/state/store';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import Login from './views/login/Login';
 import Users from './views/user/Users';
 import Jobs from './views/jobs/Jobs';
@@ -42,6 +42,7 @@ for (const [path, mod] of Object.entries(semiLocaleModules)) {
 }
 
 export default function FredyApp() {
+  const location = useLocation();
   const actions = useActions();
   const [loading, setLoading] = React.useState(true);
   const currentUser = useSelector((state) => state.user.currentUser);
@@ -85,7 +86,7 @@ export default function FredyApp() {
         {needsLogin() ? (
           <Routes>
             <Route path="/login" element={<Login />} />
-            <Route path="*" element={<Navigate to="/login" replace />} />
+            <Route path="*" element={<Navigate state={{ from: location }} to="/login" replace />} />
           </Routes>
         ) : (
           <Layout className="app">

--- a/ui/src/views/login/Login.jsx
+++ b/ui/src/views/login/Login.jsx
@@ -8,7 +8,7 @@ import React, { useEffect } from 'react';
 import cityBackground from '../../assets/city_background.jpg';
 import Logo from '../../components/logo/Logo';
 import { xhrPost } from '../../services/xhr';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useActions, useSelector } from '../../services/state/store';
 import { Input, Button, Banner } from '@douyinfe/semi-ui-19';
 
@@ -24,6 +24,7 @@ export default function Login() {
   const [error, setError] = React.useState(null);
   const demoMode = useSelector((state) => state.demoMode.demoMode || false);
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     async function init() {
@@ -52,7 +53,7 @@ export default function Login() {
     }
 
     await actions.user.getCurrentUser();
-    navigate('/dashboard');
+    navigate(location.state?.from?.pathname || '/dashboard');
   };
 
   return (


### PR DESCRIPTION
The old behaviour was: You open a page without being authorized, you are getting redirected to /login that redirects you after a successful authentication to /dashboard. This is really annoying if you want to open listenings directly from your notification adapter for example. This pull request introduces a method to redirect you back to the original page you opened after the authentication process by adding the navigation of the opened page as state to the navigation to /login. The login component than unpacks the state that contains the old navigation and redirects the user back to path from the original navigation. The path /dashboard is used as a fallback if no navigation in the state is present.

Freel free to write me if you have any questions or ideas to change here.