### PR TITLE
fix(dashboard): persist lastRun so scheduling KPIs stay in sync

### DIFF
--- a/lib/services/jobs/jobExecutionService.js
+++ b/lib/services/jobs/jobExecutionService.js
@@ -14,7 +14,7 @@ import * as similarityCache from '../similarity-check/similarityCache.js';
 import { isRunning, markFinished, markRunning } from './run-state.js';
 import { sendToUsers } from '../sse/sse-broker.js';
 import * as puppeteerExtractor from '../extractor/puppeteerExtractor.js';
-import { getSettings } from '../storage/settingsStorage.js';
+import { getSettings, upsertSettings } from '../storage/settingsStorage.js';
 
 /**
  * Initializes the job execution service.
@@ -105,6 +105,7 @@ export function initJobExecutionService({ providers, settings, intervalMs }) {
       return;
     }
     settings.lastRun = now;
+    upsertSettings({ lastRun: now });
     const jobs = jobStorage.getJobs().filter((job) => {
       if (!context) return true; // startup/cron → all
       if (context.isAdmin) return true; // admin → all


### PR DESCRIPTION
lastRun was only updated on the startup settings object while the dashboard reads a rebuilt cache after upsertSettings invalidates it.

Fixes: #324