### PR TITLE
fix(immoscout): map exclusioncriteria swapflat to mobile API value swap_flat

### DIFF
--- a/lib/services/immoscout/immoscout-web-translator.js
+++ b/lib/services/immoscout/immoscout-web-translator.js
@@ -103,6 +103,13 @@ const EQUIPMENT_MAP = {
   lodgerflat: 'lodgerflat',
 };
 
+// The web UI uses "swapflat", but the mobile API only understands "swap_flat".
+// An unknown value is not ignored: the API silently returns 0 results for the
+// whole search. Other values (e.g. "projectlisting") are identical on both APIs.
+const EXCLUSION_CRITERIA_MAP = {
+  swapflat: 'swap_flat',
+};
+
 const REAL_ESTATE_TYPE = {
   'haus-mieten': 'houserent',
   'wohnung-mieten': 'apartmentrent',
@@ -251,6 +258,9 @@ export function convertWebToMobile(webUrl) {
         ...(currentEquipmentParams ?? []),
         ...items.map((item) => EQUIPMENT_MAP[item.toLowerCase()]).filter(Boolean),
       ];
+    } else if (key === 'exclusioncriteria') {
+      const items = [].concat(val).flatMap((v) => `${v}`.split(','));
+      mobileParams[PARAM_NAME_MAP[key]] = items.map((item) => EXCLUSION_CRITERIA_MAP[item.toLowerCase()] ?? item);
     } else {
       mobileParams[PARAM_NAME_MAP[key]] = val;
     }

--- a/test/services/immoscout/immoscout-web-translator.test.js
+++ b/test/services/immoscout/immoscout-web-translator.test.js
@@ -31,10 +31,33 @@ describe('#immoscout-mobile URL conversion', () => {
     const webUrl =
       'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mieten?heatingtypes=central,selfcontainedcentral&haspromotion=false&numberofrooms=2.0-5.0&livingspace=10.0-25.0&energyefficiencyclasses=a,b,c,d,e,f,g,h,a_plus&exclusioncriteria=projectlisting,swapflat&equipment=parking,cellar,builtinkitchen,lift,garden,guesttoilet,balcony&petsallowedtypes=no,yes,negotiable&price=10.0-100.0&constructionyear=1920-2026&apartmenttypes=halfbasement,penthouse,other,loft,groundfloor,terracedflat,raisedgroundfloor,roofstorey,apartment,maisonette&pricetype=calculatedtotalrent&floor=2-7&enteredFrom=result_list';
     const expectedMobileUrl =
-      'https://api.mobile.immobilienscout24.de/search/list?apartmenttypes=halfbasement,penthouse,other,loft,groundfloor,terracedflat,raisedgroundfloor,roofstorey,apartment,maisonette&constructionyear=1920-2026&energyefficiencyclasses=a,b,c,d,e,f,g,h,a_plus&equipment=parking,cellar,builtInKitchen,lift,garden,guestToilet,balcony&exclusioncriteria=projectlisting,swapflat&floor=2-7&geocodes=%2Fde%2Fberlin%2Fberlin&haspromotion=false&heatingtypes=central,selfcontainedcentral&livingspace=10.0-25.0&numberofrooms=2.0-5.0&petsallowedtypes=no,yes,negotiable&price=10.0-100.0&pricetype=calculatedtotalrent&realestatetype=apartmentrent&searchType=region';
+      'https://api.mobile.immobilienscout24.de/search/list?apartmenttypes=halfbasement,penthouse,other,loft,groundfloor,terracedflat,raisedgroundfloor,roofstorey,apartment,maisonette&constructionyear=1920-2026&energyefficiencyclasses=a,b,c,d,e,f,g,h,a_plus&equipment=parking,cellar,builtInKitchen,lift,garden,guestToilet,balcony&exclusioncriteria=projectlisting,swap_flat&floor=2-7&geocodes=%2Fde%2Fberlin%2Fberlin&haspromotion=false&heatingtypes=central,selfcontainedcentral&livingspace=10.0-25.0&numberofrooms=2.0-5.0&petsallowedtypes=no,yes,negotiable&price=10.0-100.0&pricetype=calculatedtotalrent&realestatetype=apartmentrent&searchType=region';
 
     const actualMobileUrl = convertWebToMobile(webUrl);
     expect(actualMobileUrl).toBe(expectedMobileUrl);
+  });
+
+  // The web UI encodes "no swap flats" as exclusioncriteria=swapflat, but the
+  // mobile API only understands swap_flat. Unknown values are not ignored by the
+  // API - the search silently returns 0 results, so the mapping is essential.
+  it('should map exclusioncriteria=swapflat to the mobile API value swap_flat', () => {
+    const webUrl =
+      'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mieten?exclusioncriteria=swapflat&price=-1500.0';
+
+    const converted = convertWebToMobile(webUrl);
+    const queryParams = new URL(converted).searchParams;
+    expect(queryParams.get('exclusioncriteria')).toBe('swap_flat');
+  });
+
+  // Values the mobile API shares with the web API (e.g. projectlisting) must
+  // pass through unchanged, in any combination with mapped values.
+  it('should keep other exclusioncriteria values untouched', () => {
+    const webUrl =
+      'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mieten?exclusioncriteria=projectlisting,swapflat';
+
+    const converted = convertWebToMobile(webUrl);
+    const queryParams = new URL(converted).searchParams;
+    expect(queryParams.get('exclusioncriteria')).toBe('projectlisting,swap_flat');
   });
 
   // Test URL conversion of web-only SEO path


### PR DESCRIPTION
Fixes #331

## Problem

The web UI encodes "exclude swap flats" as `exclusioncriteria=swapflat`, but the mobile API only understands `swap_flat`. The translator passes the value through verbatim, and the API doesn't ignore unknown values — it silently returns `totalResults: 0` for the whole search. So every saved search with that filter set finds nothing, with no error anywhere.

## Fix

Added an `EXCLUSION_CRITERIA_MAP` (analogous to the existing `EQUIPMENT_MAP`) that maps `swapflat` → `swap_flat` during web→mobile conversion. All other values pass through unchanged — `projectlisting`, for example, is identical on both APIs and keeps working (verified against the live API: it actually filters results when sent as-is, and is ignored as `project_listing`).

## Verification

Live mobile API, identical shape search (Munich rentals, ≤1500 €, 1.5+ rooms), stable across repeated calls:

| `exclusioncriteria` sent | totalResults |
|---|---|
| _(none)_ | 23 |
| `swapflat` (before this PR) | **0** |
| `swap_flat` (after this PR) | 23 |
| `projectlisting,swapflat` (before) | **0** |
| `projectlisting,swap_flat` (after) | 23 |

## Tests

- Two new cases covering the mapping and the passthrough of other values
- Updated the full-URL conversion test that previously asserted the broken passthrough
- `TEST_MODE=offline npx vitest run test/services/immoscout/immoscout-web-translator.test.js` → 13/13 green, lint/prettier clean