### PR TITLE
fix: use hash-router URL format for listing links in email adapters

### DIFF
--- a/lib/notification/adapter/http.js
+++ b/lib/notification/adapter/http.js
@@ -14,7 +14,7 @@ const mapListing = (listing, baseUrl) => ({
   size: listing.size,
   title: listing.title,
   url: listing.link,
-  fredyUrl: baseUrl && listing.id ? `${baseUrl}/listings/listing/${listing.id}` : null,
+  fredyUrl: baseUrl && listing.id ? `${baseUrl}/#/listings/listing/${listing.id}` : null,
 });
 
 export const send = async ({ serviceName, newListings, notificationConfig, jobKey, baseUrl }) => {

--- a/lib/notification/adapter/mailJet.js
+++ b/lib/notification/adapter/mailJet.js
@@ -53,7 +53,7 @@ const mapListingsWithCid = async (serviceName, jobKey, listings, baseUrl) => {
       jobKey,
       hasImage: false,
       imageCid: '',
-      fredyUrl: baseUrl && l.id ? `${baseUrl}/listings/listing/${l.id}` : null,
+      fredyUrl: baseUrl && l.id ? `${baseUrl}/#/listings/listing/${l.id}` : null,
     };
 
     if (imgUrl) {

--- a/lib/notification/adapter/resend.js
+++ b/lib/notification/adapter/resend.js
@@ -25,7 +25,7 @@ const mapListings = (serviceName, jobKey, listings, baseUrl) =>
       price: l.price || '',
       image,
       hasImage: Boolean(image),
-      fredyUrl: baseUrl && l.id ? `${baseUrl}/listings/listing/${l.id}` : null,
+      fredyUrl: baseUrl && l.id ? `${baseUrl}/#/listings/listing/${l.id}` : null,
       serviceName,
       jobKey,
     };

--- a/lib/notification/adapter/sendGrid.js
+++ b/lib/notification/adapter/sendGrid.js
@@ -20,7 +20,7 @@ const mapListings = (serviceName, jobKey, listings, baseUrl) =>
       hasImage: Boolean(image),
       // optional plain text snippet
       snippet: [l.address, l.price, l.size].filter(Boolean).join(' | '),
-      fredyUrl: baseUrl && l.id ? `${baseUrl}/listings/listing/${l.id}` : null,
+      fredyUrl: baseUrl && l.id ? `${baseUrl}/#/listings/listing/${l.id}` : null,
       serviceName,
       jobKey,
     };

--- a/lib/notification/adapter/smtp.js
+++ b/lib/notification/adapter/smtp.js
@@ -25,7 +25,7 @@ const mapListings = (serviceName, jobKey, listings, baseUrl) =>
       price: l.price || '',
       image,
       hasImage: Boolean(image),
-      fredyUrl: baseUrl && l.id ? `${baseUrl}/listings/listing/${l.id}` : null,
+      fredyUrl: baseUrl && l.id ? `${baseUrl}/#/listings/listing/${l.id}` : null,
       serviceName,
       jobKey,
     };


### PR DESCRIPTION
Fixes #333

## Problem

The UI is a `HashRouter` app, and most adapters already link to `${baseUrl}/#/listings/listing/:id`. The email adapters (resend, smtp, mailJet, sendGrid) and the http adapter build the link without the `/#`, so the router ignores the route and the user lands on the overview instead of the listing.

## Fix

Added the `/#` to the five remaining adapters — they now produce the exact same URL shape as telegram, slack, discord, ntfy, mattermost, pushover, apprise and console.

## Verified

Headless Chrome against a live instance: the hash-format URL goes login → exact listing detail (the post-login redirect keeps the deep link intact), while the old path-format URL ends on `#/dashboard`.