### PR TITLE
fix: use absolute Vite base so path-style URLs don't white-screen

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,10 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '',
+  // Must be absolute: with a relative base, asset URLs in index.html break on
+  // deep links like /listings/listing/:id (the SPA fallback serves index.html,
+  // but ./assets/* then resolves below the route path and loads HTML as JS).
+  base: '/',
   build: {
     chunkSizeWarningLimit: 9999999,
     outDir: './ui/public',


### PR DESCRIPTION
Fixes #334

## Problem

With `base: ''` the built `index.html` references assets relatively (`./assets/*`). On any nested path — e.g. the `/listings/listing/:id` links every released email adapter has been sending — the browser requests `/listings/listing/assets/index-*.js`, the SPA fallback answers with `index.html`, and the module loader refuses to execute HTML. The user sees a white screen with no hint of what went wrong.

## Fix

`base: '/'`, plus a short comment explaining why it must stay absolute. Assets now resolve from the root regardless of URL depth, so legacy path-style links load the app normally (the `HashRouter` then shows the default view) instead of dying. #335 fixes the link format itself going forward.

## Verified

After deploying this to a live instance:

```
GET /listings/listing/<id>  → index.html with src="/assets/index-*.js"
GET /assets/index-*.js      → 200 application/javascript
```

Previously the nested asset request returned `text/html`. Production build output checked locally (`yarn run build:frontend`), all asset refs absolute.