### PR TITLE
feat: attach listing images in Apprise adapter

### DIFF
--- a/lib/notification/adapter/apprise.js
+++ b/lib/notification/adapter/apprise.js
@@ -7,15 +7,38 @@ import { markdown2Html } from '../../services/markdown.js';
 import { getJob } from '../../services/storage/jobStorage.js';
 import fetch from 'node-fetch';
 
-export const send = ({ serviceName, newListings, notificationConfig, jobKey, baseUrl }) => {
+export const send = async ({ serviceName, newListings, notificationConfig, jobKey, baseUrl }) => {
   const { server } = notificationConfig.find((adapter) => adapter.id === config.id).fields;
   const job = getJob(jobKey);
   const jobName = job == null ? jobKey : job.name;
-  const promises = newListings.map((newListing) => {
+
+  for (const newListing of newListings) {
     const title = `${jobName} at ${serviceName}: ${newListing.title}`;
     const fredyLine = baseUrl && newListing.id ? `\nOpen in Fredy: ${baseUrl}/#/listings/listing/${newListing.id}` : '';
     const message = `Address: ${newListing.address}\nSize: ${newListing.size}\nPrice: ${newListing.price}\nLink: ${newListing.link}${fredyLine}`;
-    return fetch(server, {
+
+    // Try to attach image if available
+    if (newListing.image && typeof newListing.image === 'string') {
+      try {
+        const imgRes = await fetch(newListing.image);
+        if (imgRes.ok) {
+          const ab = await imgRes.arrayBuffer();
+          const form = new FormData();
+          form.append('body', message);
+          form.append('title', title);
+          form.append('attachment', new Blob([ab]), 'image.jpg');
+          await fetch(server, {
+            method: 'POST',
+            body: form,
+          });
+          continue;
+        }
+      } catch {
+        // fail silently, just skip the image
+      }
+    }
+
+    await fetch(server, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -23,8 +46,7 @@ export const send = ({ serviceName, newListings, notificationConfig, jobKey, bas
         title: title,
       }),
     });
-  });
-  return Promise.all(promises);
+  }
 };
 export const config = {
   id: 'apprise',


### PR DESCRIPTION
## Summary

The Apprise adapter currently sends JSON `{ body, title }` only. Listing images are never forwarded, so downstream services (Discord, Pushover, etc.) receive text-only notifications even when Apprise itself supports attachments.

This change mirrors the existing Pushover adapter: fetch the listing image and POST it to the Apprise API as a multipart `attachment`. If the image cannot be fetched, notification still goes out without an attachment (same JSON fallback as before).

Notifications are sent sequentially instead of in parallel so Discord receives each listing's text and image in order when Apprise posts them separately.

## Changes

- Fetch `newListing.image` and attach it as a binary upload when available
- Use multipart `FormData` for requests with an attachment; keep JSON POST when there is no image
- Send one listing at a time (`for` + `await`) instead of `Promise.all`

## Test plan

- [ ] Configure Apprise adapter with a stateful notify URL (e.g. `http://apprise:8000/notify/<config_id>`)
- [ ] Run a job that finds new listings with images
- [ ] Confirm Pushover/Discord receive the listing photo via Apprise
- [ ] Confirm notifications still work when a listing has no image
- [ ] Confirm a broken image URL still sends the text notification (JSON fallback)
- [ ] With multiple new listings, confirm Discord messages stay in listing order (text/image pairs, not all text then all images)