### PR TITLE
feat(listings): implement live reload for new listings using SSE

### DIFF
--- a/lib/FredyPipelineExecutioner.js
+++ b/lib/FredyPipelineExecutioner.js
@@ -98,6 +98,7 @@ class FredyPipelineExecutioner {
       .then(this._filterBySimilarListings.bind(this))
       .then(this._filterBySpecs.bind(this))
       .then(this._filterByArea.bind(this))
+      .then(this._sendNewListingsToUser.bind(this))
       .then(this._notify.bind(this))
       .catch(this._handleError.bind(this));
   }
@@ -367,7 +368,16 @@ class FredyPipelineExecutioner {
   _save(newListings) {
     logger.debug(`Storing ${newListings.length} new listings (Provider: '${this._providerId}')`);
     storeListings(this._jobKey, this._providerId, newListings);
+    return newListings;
+  }
 
+  /**
+   * Broadcast real-time live reload event to user via SSE broker.
+   *
+   * @param {ParsedListing[]} newListings New listings to broadcast.
+   * @returns {ParsedListing[]} The same listings, unchanged.
+   */
+  _sendNewListingsToUser(newListings) {
     if (newListings.length > 0) {
       try {
         const job = getJob(this._jobKey);
@@ -379,7 +389,6 @@ class FredyPipelineExecutioner {
         logger.error('Error broadcasting listings:new event', err);
       }
     }
-
     return newListings;
   }
 

--- a/lib/FredyPipelineExecutioner.js
+++ b/lib/FredyPipelineExecutioner.js
@@ -11,6 +11,7 @@ import {
   updateListingDistance,
 } from './services/storage/listingsStorage.js';
 import { getJob } from './services/storage/jobStorage.js';
+import { sendToUser } from './services/sse/sse-broker.js';
 import * as notify from './notification/notify.js';
 import Extractor from './services/extractor/extractor.js';
 import urlModifier from './services/queryStringMutator.js';
@@ -366,6 +367,19 @@ class FredyPipelineExecutioner {
   _save(newListings) {
     logger.debug(`Storing ${newListings.length} new listings (Provider: '${this._providerId}')`);
     storeListings(this._jobKey, this._providerId, newListings);
+    
+    if (newListings.length > 0) {
+      try {
+        const job = getJob(this._jobKey);
+        const userId = job?.userId;
+        if (userId) {
+          sendToUser(userId, 'listings:new', { jobId: this._jobKey, count: newListings.length });
+        }
+      } catch (err) {
+        logger.error('Error broadcasting listings:new event', err);
+      }
+    }
+    
     return newListings;
   }
 

--- a/lib/FredyPipelineExecutioner.js
+++ b/lib/FredyPipelineExecutioner.js
@@ -367,7 +367,7 @@ class FredyPipelineExecutioner {
   _save(newListings) {
     logger.debug(`Storing ${newListings.length} new listings (Provider: '${this._providerId}')`);
     storeListings(this._jobKey, this._providerId, newListings);
-    
+
     if (newListings.length > 0) {
       try {
         const job = getJob(this._jobKey);
@@ -379,7 +379,7 @@ class FredyPipelineExecutioner {
         logger.error('Error broadcasting listings:new event', err);
       }
     }
-    
+
     return newListings;
   }
 

--- a/test/pipeline_filtering.test.js
+++ b/test/pipeline_filtering.test.js
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, expect } from 'vitest';
-import { mockFredy } from './utils.js';
+import { mockFredy, sseEvents } from './utils.js';
 import * as mockStore from './mocks/mockStore.js';
 import { get as getLastNotification } from './mocks/mockNotification.js';
 
@@ -332,5 +332,59 @@ describe('Blacklist is re-applied after detail enrichment', () => {
     // Listing leaks through because user has not opted in to the stricter check.
     expect(result).toBeInstanceOf(Array);
     expect(result.map((l) => l.id)).toContain('leaks-through');
+  });
+});
+
+describe('Live reload triggers via SSE', () => {
+  afterEach(() => {
+    sseEvents.length = 0;
+  });
+
+  it('emits a listings:new event via SSE when a new listing is saved', async () => {
+    sseEvents.length = 0;
+    const Fredy = await mockFredy();
+
+    const mockSimilarityCache = {
+      checkAndAddEntry: () => false, // unique listing
+    };
+
+    const providerConfig = {
+      url: 'http://example.com',
+      getListings: () =>
+        Promise.resolve([
+          {
+            id: 'brand-new-listing',
+            title: 'Cool Apartment',
+            address: 'Awesome Ave',
+            price: '500',
+            link: 'http://example.com/new',
+          },
+        ]),
+      normalize: (l) => l,
+      filter: () => true,
+      crawlFields: { id: 'id', title: 'title', address: 'address', price: 'price', link: 'link' },
+      requiredFieldNames: ['id', 'title', 'address', 'price', 'link'],
+    };
+
+    const mockedJob = {
+      id: 'live-reload-job',
+      notificationAdapter: null,
+      specFilter: null,
+      spatialFilter: null,
+    };
+
+    const fredy = new Fredy(providerConfig, mockedJob, 'live-reload-provider', mockSimilarityCache, undefined);
+
+    await fredy.execute();
+
+    expect(sseEvents).toHaveLength(1);
+    expect(sseEvents[0]).toEqual({
+      userId: 'user1',
+      event: 'listings:new',
+      data: {
+        jobId: 'live-reload-job',
+        count: 1,
+      },
+    });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -12,6 +12,8 @@ export const providerConfig = JSON.parse(
   await readFile(new URL('./provider/testProvider.json', import.meta.url), 'utf-8'),
 );
 
+export const sseEvents = [];
+
 vi.mock('../lib/services/storage/listingsStorage.js', () => mockStore);
 vi.mock('../lib/services/storage/settingsStorage.js', () => mockStore);
 vi.mock('../lib/services/geocoding/geoCodingService.js', () => ({
@@ -19,6 +21,11 @@ vi.mock('../lib/services/geocoding/geoCodingService.js', () => ({
 }));
 vi.mock('../lib/services/storage/jobStorage.js', () => ({
   getJob: (jobKey) => ({ id: jobKey, userId: 'user1' }),
+}));
+vi.mock('../lib/services/sse/sse-broker.js', () => ({
+  sendToUser: (userId, event, data) => {
+    sseEvents.push({ userId, event, data });
+  },
 }));
 vi.mock('../lib/notification/notify.js', () => ({ send }));
 

--- a/ui/src/components/listings/ListingsOverview.jsx
+++ b/ui/src/components/listings/ListingsOverview.jsx
@@ -3,7 +3,7 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import {
   useSearchParamState,
   parseNumber,
@@ -103,6 +103,41 @@ const ListingsOverview = ({ mode = 'all' }) => {
     hiddenOnly,
     isWatchlistMode,
   ]);
+
+  const loadDataRef = useRef(loadData);
+  useEffect(() => {
+    loadDataRef.current = loadData;
+  }, [loadData]);
+
+  // SSE connection for live listings updates
+  useEffect(() => {
+    const src = new EventSource('/api/jobs/events');
+
+    const onNewListings = (e) => {
+      try {
+        const data = JSON.parse(e.data || '{}');
+        if (data && data.count) {
+          loadDataRef.current();
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+
+    src.addEventListener('listings:new', onNewListings);
+    src.onerror = () => {
+      // Let browser auto-reconnect
+    };
+
+    return () => {
+      try {
+        src.removeEventListener('listings:new', onNewListings);
+        src.close();
+      } catch {
+        // noop
+      }
+    };
+  }, [t]);
 
   const handleFilterChange = useMemo(
     () =>

--- a/ui/src/components/listings/ListingsOverview.jsx
+++ b/ui/src/components/listings/ListingsOverview.jsx
@@ -64,6 +64,7 @@ const ListingsOverview = ({ mode = 'all' }) => {
   const [hiddenOnly, setHiddenOnly] = useSearchParamState(sp, 'hidden', false, parseNullableBoolean);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
   const [listingToDelete, setListingToDelete] = useState(null);
+  const [newAvailableCount, setNewAvailableCount] = useState(0);
 
   const isHiddenView = hiddenOnly === true;
 
@@ -90,6 +91,7 @@ const ListingsOverview = ({ mode = 'all' }) => {
 
   useEffect(() => {
     loadData();
+    setNewAvailableCount(0);
   }, [
     page,
     sortField,
@@ -117,7 +119,7 @@ const ListingsOverview = ({ mode = 'all' }) => {
       try {
         const data = JSON.parse(e.data || '{}');
         if (data && data.count) {
-          loadDataRef.current();
+          setNewAvailableCount((prev) => prev + data.count);
         }
       } catch {
         // ignore malformed events
@@ -400,6 +402,32 @@ const ListingsOverview = ({ mode = 'all' }) => {
           </Tooltip>
         </div>
       </div>
+
+      {newAvailableCount > 0 && (
+        <Banner
+          type="info"
+          fullMode={false}
+          closeIcon={null}
+          description={
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+              <span>{t('listings.newAvailableBanner', { count: newAvailableCount })}</span>
+              <Button
+                size="small"
+                theme="solid"
+                type="primary"
+                onClick={() => {
+                  loadDataRef.current();
+                  setNewAvailableCount(0);
+                }}
+                style={{ marginLeft: 16 }}
+              >
+                {t('listings.reloadButton')}
+              </Button>
+            </div>
+          }
+          style={{ marginBottom: 12 }}
+        />
+      )}
 
       {isHiddenView && (
         <Banner

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -154,6 +154,8 @@
   "listings.filterSortHelp": "Wählt das Sortierkriterium. Mit dem Pfeil-Button schaltet man zwischen aufsteigend und absteigend.",
   "listings.hiddenViewBanner": "Du siehst gerade versteckte (soft-gelöschte) Inserate. Sie werden in den normalen Ansichten ausgeblendet. Über den Wiederherstellen-Button kannst du sie zurückholen.",
   "listings.toastRestored": "Inserat wiederhergestellt",
+  "listings.newAvailableBanner": "Neue Inserate verfügbar! ({{count}})",
+  "listings.reloadButton": "Aktualisieren",
   "listings.toastRestoreError": "Wiederherstellung fehlgeschlagen",
   "listings.tooltipUndelete": "Inserat wiederherstellen",
   "listings.sortByJobName": "Job-Name",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -154,6 +154,8 @@
   "listings.filterSortHelp": "Choose the column to sort listings by. Use the arrow button to toggle ascending and descending order.",
   "listings.hiddenViewBanner": "You are viewing hidden (soft-deleted) listings. They are excluded from the regular views. Use the restore button on a card to bring it back.",
   "listings.toastRestored": "Listing restored",
+  "listings.newAvailableBanner": "New listings available! ({{count}})",
+  "listings.reloadButton": "Refresh",
   "listings.toastRestoreError": "Failed to restore listing",
   "listings.tooltipUndelete": "Restore Listing",
   "listings.sortByJobName": "Job Name",


### PR DESCRIPTION
This PR implements real-time silent live-reloading for the listings overview page. 

Currently when new listings are fetched and stored by background/scheduled jobs, users on the Listings page do not see them unless they manually reload the page. This breaks the seamless real-time feel of the application.

**Solution:**
We leverage Fredys existing SSE architecture to silently reload the listings state in the background.

**Backend**:
  - Automatically dispatches a `listings:new` event through SSE to the user when new listings are added to the database

**Frontend**:
  - Subscribed to the `/api/jobs/events` SSE channel
  - Refetches the listings page silently when a `listings:new` event is received