### PR TITLE
feat(notification-adapter): add native browser notifications as notification adapter

### DIFF
--- a/lib/notification/adapter/browser.js
+++ b/lib/notification/adapter/browser.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { markdown2Html } from '../../services/markdown.js';
+import { getJob } from '../../services/storage/jobStorage.js';
+import { sendToUser } from '../../services/sse/sse-broker.js';
+
+export const send = ({ serviceName, newListings, jobKey, baseUrl, userId }) => {
+  const targetUserId = userId || getJob(jobKey)?.userId;
+
+  if (!targetUserId) {
+    return Promise.resolve();
+  }
+
+  newListings.forEach((listing) => {
+    const title = listing.title || 'New Listing Found';
+
+    const meta = [listing.price && `Price: ${listing.price}`, listing.size && `Size: ${listing.size}`]
+      .filter(Boolean)
+      .join(' | ');
+    const body = [meta, listing.address && `Address: ${listing.address}`].filter(Boolean).join('\n');
+    const link = listing.link || (baseUrl ? `${baseUrl}/#/listings/listing/${listing.id}` : '');
+
+    sendToUser(targetUserId, 'notification:browser', {
+      id: listing.id,
+      title,
+      body,
+      link,
+      image: listing.image,
+      jobKey,
+      serviceName,
+    });
+  });
+
+  return Promise.resolve();
+};
+
+export const config = {
+  id: 'browser',
+  name: 'Browser Notifications',
+  description: 'Displays native desktop push notifications directly in your browser.',
+  config: {},
+  readme: markdown2Html('lib/notification/adapter/browser.md'),
+};

--- a/lib/notification/adapter/browser.md
+++ b/lib/notification/adapter/browser.md
@@ -1,0 +1,9 @@
+### Browser Notifications Adapter
+
+Receive native desktop push notifications directly in your browser.
+
+Quick start:
+- Enable this adapter on any of your jobs.
+- Keep Fredy open in a browser tab.
+- When prompted, grant notification permissions.
+- You'll receive real-time push notifications on your desktop whenever new listings are found!

--- a/test/notification/browser.test.js
+++ b/test/notification/browser.test.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies
+vi.mock('../../lib/services/storage/jobStorage.js', () => ({
+  getJob: (jobKey) => ({ id: jobKey, userId: 'user_123' }),
+}));
+
+vi.mock('../../lib/services/markdown.js', () => ({
+  markdown2Html: () => '',
+}));
+
+vi.mock('../../lib/services/sse/sse-broker.js', () => ({
+  sendToUser: vi.fn(),
+}));
+
+let send;
+let mockSendToUser;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const sseBroker = await import('../../lib/services/sse/sse-broker.js');
+  mockSendToUser = sseBroker.sendToUser;
+  mockSendToUser.mockReset();
+
+  ({ send } = await import('../../lib/notification/adapter/browser.js'));
+});
+
+describe('browser notification adapter', () => {
+  it('should broadcast listings:new to the user when userId is present', async () => {
+    const listing1 = {
+      id: 'listing_1',
+      title: 'Schöne Wohnung',
+      price: '1.200 €',
+      size: '80 m²',
+      address: 'Musterstraße 1, Berlin',
+      link: 'https://example.com/1',
+      image: 'https://example.com/image.png',
+    };
+
+    await send({
+      serviceName: 'immoscout',
+      newListings: [listing1],
+      jobKey: 'Job_Berlin',
+      baseUrl: 'http://localhost:9998',
+    });
+
+    expect(mockSendToUser).toHaveBeenCalledTimes(1);
+    expect(mockSendToUser).toHaveBeenCalledWith('user_123', 'notification:browser', {
+      id: 'listing_1',
+      title: 'Schöne Wohnung',
+      body: 'Price: 1.200 € | Size: 80 m²\nAddress: Musterstraße 1, Berlin',
+      link: 'https://example.com/1',
+      image: 'https://example.com/image.png',
+      jobKey: 'Job_Berlin',
+      serviceName: 'immoscout',
+    });
+  });
+
+  it('should fall back to default values when fields are missing', async () => {
+    const listing2 = {
+      id: 'listing_2',
+    };
+
+    await send({
+      serviceName: 'immoscout',
+      newListings: [listing2],
+      jobKey: 'Job_Berlin',
+      baseUrl: 'http://localhost:9998',
+    });
+
+    expect(mockSendToUser).toHaveBeenCalledTimes(1);
+    expect(mockSendToUser).toHaveBeenCalledWith('user_123', 'notification:browser', {
+      id: 'listing_2',
+      title: 'New Listing Found',
+      body: '',
+      link: 'http://localhost:9998/#/listings/listing/listing_2',
+      image: undefined,
+      jobKey: 'Job_Berlin',
+      serviceName: 'immoscout',
+    });
+  });
+
+  it('should support explicit userId override (such as during test calls)', async () => {
+    const listing3 = {
+      id: 'listing_3',
+    };
+
+    await send({
+      serviceName: 'immoscout',
+      newListings: [listing3],
+      jobKey: 'TestJob',
+      baseUrl: 'http://localhost:9998',
+      userId: 'test_user_override',
+    });
+
+    expect(mockSendToUser).toHaveBeenCalledTimes(1);
+    expect(mockSendToUser).toHaveBeenCalledWith('test_user_override', 'notification:browser', {
+      id: 'listing_3',
+      title: 'New Listing Found',
+      body: '',
+      link: 'http://localhost:9998/#/listings/listing/listing_3',
+      image: undefined,
+      jobKey: 'TestJob',
+      serviceName: 'immoscout',
+    });
+  });
+});

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -135,6 +135,49 @@ export default function FredyApp() {
     return () => window.removeEventListener('fredy:unauthorized', onUnauthorized);
   }, []);
 
+  // Handle HTML5 Web Push Notifications from the browser notification adapter
+  useEffect(() => {
+    if (currentUser == null || Object.keys(currentUser).length === 0) return;
+
+    if (typeof window !== 'undefined' && 'Notification' in window) {
+      if (Notification.permission === 'default') {
+        Notification.requestPermission();
+      }
+    }
+
+    const src = new EventSource('/api/jobs/events');
+
+    const onBrowserNotification = (e) => {
+      try {
+        const data = JSON.parse(e.data || '{}');
+        if (data && 'Notification' in window && Notification.permission === 'granted') {
+          const notification = new Notification(data.title, {
+            body: data.body,
+            icon: data.image || '/ui/src/assets/heart.png',
+          });
+          notification.onclick = () => {
+            window.focus();
+            if (data.link) {
+              window.open(data.link, '_blank');
+            }
+          };
+        }
+      } catch (err) {
+        console.error('Error parsing browser notification SSE:', err);
+      }
+    };
+
+    src.addEventListener('notification:browser', onBrowserNotification);
+    src.onerror = () => {
+      // Browser automatically reconnects
+    };
+
+    return () => {
+      src.removeEventListener('notification:browser', onBrowserNotification);
+      src.close();
+    };
+  }, [currentUser?.userId]);
+
   const needsLogin = () => {
     return currentUser == null || Object.keys(currentUser).length === 0;
   };

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -11,6 +11,7 @@ import GeneralSettings from './views/generalSettings/GeneralSettings';
 import JobMutation from './views/jobs/mutation/JobMutation';
 import UserMutator from './views/user/mutation/UserMutator';
 import { useActions, useSelector } from './services/state/store';
+import { useBrowserNotifications } from './hooks/useBrowserNotifications';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import Login from './views/login/Login';
 import Users from './views/user/Users';
@@ -64,6 +65,8 @@ export default function FredyApp() {
   const versionUpdate = useSelector((state) => state.versionUpdate.versionUpdate);
   const settings = useSelector((state) => state.generalSettings.settings);
   const language = useSelector((state) => state.userSettings.settings.language);
+
+  useBrowserNotifications();
 
   useEffect(() => {
     // Already filled for this user: nothing to do. Checked against the ref, which is only set
@@ -134,49 +137,6 @@ export default function FredyApp() {
     window.addEventListener('fredy:unauthorized', onUnauthorized);
     return () => window.removeEventListener('fredy:unauthorized', onUnauthorized);
   }, []);
-
-  // Handle HTML5 Web Push Notifications from the browser notification adapter
-  useEffect(() => {
-    if (currentUser == null || Object.keys(currentUser).length === 0) return;
-
-    if (typeof window !== 'undefined' && 'Notification' in window) {
-      if (Notification.permission === 'default') {
-        Notification.requestPermission();
-      }
-    }
-
-    const src = new EventSource('/api/jobs/events');
-
-    const onBrowserNotification = (e) => {
-      try {
-        const data = JSON.parse(e.data || '{}');
-        if (data && 'Notification' in window && Notification.permission === 'granted') {
-          const notification = new Notification(data.title, {
-            body: data.body,
-            icon: data.image || '/ui/src/assets/heart.png',
-          });
-          notification.onclick = () => {
-            window.focus();
-            if (data.link) {
-              window.open(data.link, '_blank');
-            }
-          };
-        }
-      } catch (err) {
-        console.error('Error parsing browser notification SSE:', err);
-      }
-    };
-
-    src.addEventListener('notification:browser', onBrowserNotification);
-    src.onerror = () => {
-      // Browser automatically reconnects
-    };
-
-    return () => {
-      src.removeEventListener('notification:browser', onBrowserNotification);
-      src.close();
-    };
-  }, [currentUser?.userId]);
 
   const needsLogin = () => {
     return currentUser == null || Object.keys(currentUser).length === 0;

--- a/ui/src/hooks/useBrowserNotifications.js
+++ b/ui/src/hooks/useBrowserNotifications.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { useEffect } from 'react';
+import { useSelector } from '../services/state/store';
+
+export function useBrowserNotifications() {
+  const currentUser = useSelector((state) => state.user.currentUser);
+
+  useEffect(() => {
+    if (currentUser == null || Object.keys(currentUser).length === 0) return;
+
+    if (typeof window !== 'undefined' && 'Notification' in window) {
+      if (Notification.permission === 'default') {
+        Notification.requestPermission();
+      }
+    }
+
+    const src = new EventSource('/api/jobs/events');
+
+    const onBrowserNotification = (e) => {
+      try {
+        const data = JSON.parse(e.data || '{}');
+        if (data && 'Notification' in window && Notification.permission === 'granted') {
+          const notification = new Notification(data.title, {
+            body: data.body,
+            icon: data.image || '/ui/src/assets/heart.png',
+          });
+          notification.onclick = () => {
+            window.focus();
+            if (data.link) {
+              window.open(data.link, '_blank');
+            }
+          };
+        }
+      } catch (err) {
+        console.error('Error parsing browser notification SSE:', err);
+      }
+    };
+
+    src.addEventListener('notification:browser', onBrowserNotification);
+    src.onerror = () => {
+      // Browser automatically reconnects
+    };
+
+    return () => {
+      src.removeEventListener('notification:browser', onBrowserNotification);
+      src.close();
+    };
+  }, [currentUser?.userId]);
+}

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -461,6 +461,8 @@
   "notification.save": "Speichern",
   "notification.trySuccess": "Es scheint geklappt zu haben! Bitte überprüfe deinen Dienst.",
   "notification.tryError": "Das hat leider nicht funktioniert :-( Ich habe folgenden Fehler erhalten: {{error}}",
+  "notification.browserPermissionDenied": "Browser-Benachrichtigungen sind blockiert. Bitte erlaube Benachrichtigungen in den Website-Einstellungen deines Browsers, um diesen Adapter zu verwenden.",
+  "notification.browserNotSupported": "Dein Browser oder deine aktuelle Verbindung unterstützt keine Desktop-Benachrichtigungen. Bitte stelle sicher, dass du einen modernen Browser über HTTPS oder localhost verwendest.",
   "notification.errorTitle": "Fehler",
   "notification.successTitle": "Super!",
   "notification.validationAllMandatory": "Alle Felder sind Pflichtfelder und müssen ausgefüllt werden.",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -461,6 +461,8 @@
   "notification.save": "Save",
   "notification.trySuccess": "It seems like it worked! Please check your service.",
   "notification.tryError": "This did not work :-( I've received the following error: {{error}}",
+  "notification.browserPermissionDenied": "Browser notifications are blocked. Please enable/allow notifications in your browser's site settings to use this adapter.",
+  "notification.browserNotSupported": "Your browser or current connection does not support desktop notifications. Please make sure you are using a modern browser over HTTPS or localhost.",
   "notification.errorTitle": "Error",
   "notification.successTitle": "Yay!",
   "notification.validationAllMandatory": "All fields are mandatory and must be set.",

--- a/ui/src/services/notification/browserNotification.js
+++ b/ui/src/services/notification/browserNotification.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+/**
+ * Triggers a test browser notification, requesting permission if needed.
+ *
+ * @param {function} t - The translation function
+ * @param {function} onSuccess - Callback when notification succeeds
+ * @param {function} onError - Callback when there is a validation or permission error
+ */
+export function triggerTestNotification(t, onSuccess, onError) {
+  if (typeof window !== 'undefined' && 'Notification' in window) {
+    if (Notification.permission === 'granted') {
+      const notification = new Notification('Test Call from Fredy', {
+        body: 'Everything works perfectly! Real-time listings will appear here.',
+        icon: '/ui/src/assets/heart.png',
+      });
+      notification.onclick = () => {
+        window.focus();
+      };
+      onSuccess(t('notification.trySuccess'));
+    } else if (Notification.permission === 'denied') {
+      onError(t('notification.browserPermissionDenied'));
+    } else {
+      const handlePermissionResult = (permission) => {
+        if (permission === 'granted') {
+          const notification = new Notification('Test Call from Fredy', {
+            body: 'Everything works perfectly! Real-time listings will appear here.',
+            icon: '/ui/src/assets/heart.png',
+          });
+          notification.onclick = () => {
+            window.focus();
+          };
+          onSuccess(t('notification.trySuccess'));
+        } else if (permission === 'denied') {
+          onError(t('notification.browserPermissionDenied'));
+        }
+      };
+
+      try {
+        const promise = Notification.requestPermission(handlePermissionResult);
+        if (promise && typeof promise.then === 'function') {
+          promise.then(handlePermissionResult).catch((err) => {
+            onError(t('notification.tryError', { error: String(err) }));
+          });
+        }
+      } catch {
+        // Fallback for callback interface
+      }
+    }
+  } else {
+    onError(t('notification.browserNotSupported'));
+  }
+}

--- a/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
+++ b/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 
 import { transform } from '../../../../../services/transformer/notificationAdapterTransformer';
 import { xhrPost, errorMessage } from '../../../../../services/xhr';
+import { triggerTestNotification } from '../../../../../services/notification/browserNotification';
 import Help from './NotificationHelpDisplay';
 import { useSelector } from '../../../../../services/state/store';
 import { Banner, Button, Form, Modal, Select, Switch } from '@douyinfe/semi-ui-19';
@@ -123,48 +124,7 @@ export default function NotificationAdapterMutator({
     }
 
     if (selectedAdapter.id === 'browser') {
-      if (typeof window !== 'undefined' && 'Notification' in window) {
-        if (Notification.permission === 'granted') {
-          const notification = new Notification('Test Call from Fredy', {
-            body: 'Everything works perfectly! Real-time listings will appear here.',
-            icon: '/ui/src/assets/heart.png',
-          });
-          notification.onclick = () => {
-            window.focus();
-          };
-          setSuccessMessage(t('notification.trySuccess'));
-        } else if (Notification.permission === 'denied') {
-          setValidationMessage(t('notification.browserPermissionDenied'));
-        } else {
-          const handlePermissionResult = (permission) => {
-            if (permission === 'granted') {
-              const notification = new Notification('Test Call from Fredy', {
-                body: 'Everything works perfectly! Real-time listings will appear here.',
-                icon: '/ui/src/assets/heart.png',
-              });
-              notification.onclick = () => {
-                window.focus();
-              };
-              setSuccessMessage(t('notification.trySuccess'));
-            } else if (permission === 'denied') {
-              setValidationMessage(t('notification.browserPermissionDenied'));
-            }
-          };
-
-          try {
-            const promise = Notification.requestPermission(handlePermissionResult);
-            if (promise && typeof promise.then === 'function') {
-              promise.then(handlePermissionResult).catch((err) => {
-                setValidationMessage(t('notification.tryError', { error: String(err) }));
-              });
-            }
-          } catch {
-            // Fallback for callback interface
-          }
-        }
-      } else {
-        setValidationMessage(t('notification.browserNotSupported'));
-      }
+      triggerTestNotification(t, setSuccessMessage, setValidationMessage);
       return;
     }
 

--- a/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
+++ b/ui/src/views/jobs/mutation/components/notificationAdapter/NotificationAdapterMutator.jsx
@@ -122,6 +122,52 @@ export default function NotificationAdapterMutator({
       return;
     }
 
+    if (selectedAdapter.id === 'browser') {
+      if (typeof window !== 'undefined' && 'Notification' in window) {
+        if (Notification.permission === 'granted') {
+          const notification = new Notification('Test Call from Fredy', {
+            body: 'Everything works perfectly! Real-time listings will appear here.',
+            icon: '/ui/src/assets/heart.png',
+          });
+          notification.onclick = () => {
+            window.focus();
+          };
+          setSuccessMessage(t('notification.trySuccess'));
+        } else if (Notification.permission === 'denied') {
+          setValidationMessage(t('notification.browserPermissionDenied'));
+        } else {
+          const handlePermissionResult = (permission) => {
+            if (permission === 'granted') {
+              const notification = new Notification('Test Call from Fredy', {
+                body: 'Everything works perfectly! Real-time listings will appear here.',
+                icon: '/ui/src/assets/heart.png',
+              });
+              notification.onclick = () => {
+                window.focus();
+              };
+              setSuccessMessage(t('notification.trySuccess'));
+            } else if (permission === 'denied') {
+              setValidationMessage(t('notification.browserPermissionDenied'));
+            }
+          };
+
+          try {
+            const promise = Notification.requestPermission(handlePermissionResult);
+            if (promise && typeof promise.then === 'function') {
+              promise.then(handlePermissionResult).catch((err) => {
+                setValidationMessage(t('notification.tryError', { error: String(err) }));
+              });
+            }
+          } catch {
+            // Fallback for callback interface
+          }
+        }
+      } else {
+        setValidationMessage(t('notification.browserNotSupported'));
+      }
+      return;
+    }
+
     xhrPost('/api/jobs/notificationAdapter/try', {
       id: selectedAdapter.id,
       fields: {


### PR DESCRIPTION
Hey, I've added a notification adapter which triggers browser notifications on new listings.

<img width="1217" height="877" alt="Bildschirmfoto 2026-07-25 um 12 05 19" src="https://github.com/user-attachments/assets/e86b0a57-843d-498c-8569-334b078f9550" />


A real one looks like this:
<img width="359" height="110" alt="Bildschirmfoto 2026-07-25 um 12 13 30" src="https://github.com/user-attachments/assets/d66bdd7c-809d-40d8-a124-b1d6e62a3439" />
