### PR TITLE
fix(security): salt password hashes with scrypt (CWE-328)

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ if (settings.demoMode) {
   logger.info('Running in demo mode');
 }
 
-ensureAdminUserExists();
-ensureDemoUserExists();
+await ensureAdminUserExists();
+await ensureDemoUserExists();
 await initTrackerCron();
 //do not wait for this to finish, let it run in the background
 initActiveCheckerCron();

--- a/lib/api/routes/generalSettingsRoute.js
+++ b/lib/api/routes/generalSettingsRoute.js
@@ -40,7 +40,7 @@ export default async function generalSettingsPlugin(fastify) {
       }
 
       upsertSettings(appSettings);
-      ensureDemoUserExists();
+      await ensureDemoUserExists();
       if (appSettings.baseUrl != null) {
         await trackPoi(TRACKING_POIS.BASE_URL_SETTING);
       }

--- a/lib/api/routes/loginRoute.js
+++ b/lib/api/routes/loginRoute.js
@@ -67,7 +67,7 @@ export default async function loginPlugin(fastify) {
     if (user == null) {
       return reply.code(401).send();
     }
-    if (user.password === hasher.hash(password)) {
+    if (await hasher.verify(password, user.password)) {
       if (settings.demoMode) {
         await trackDemoAccessed();
       }
@@ -75,6 +75,16 @@ export default async function loginPlugin(fastify) {
       request.session.createdAt = Date.now();
       loginAttempts.delete(ip);
       userStorage.setLastLoginToNow({ userId: user.id });
+      // Transparently upgrade legacy (unsalted SHA-256) hashes to the current
+      // salted scheme now that we have the plaintext password in hand.
+      if (hasher.needsRehash(user.password)) {
+        try {
+          const upgraded = await hasher.hash(password);
+          userStorage.updatePasswordHash({ userId: user.id, passwordHash: upgraded });
+        } catch (err) {
+          logger.error(`Failed to upgrade password hash for user ${user.id}: ${err?.message || err}`);
+        }
+      }
       return reply.code(200).send();
     } else {
       logger.error(`User ${username} tried to login, but password was wrong.`);

--- a/lib/api/routes/userRoute.js
+++ b/lib/api/routes/userRoute.js
@@ -69,7 +69,7 @@ export default async function userPlugin(fastify) {
         error: 'You cannot change the admin flag for this user as otherwise, there is no other user in the system',
       });
     }
-    userStorage.upsertUser({ userId, username, password, isAdmin });
+    await userStorage.upsertUser({ userId, username, password, isAdmin });
     return reply.send();
   });
 }

--- a/lib/services/security/hash.js
+++ b/lib/services/security/hash.js
@@ -4,4 +4,118 @@
  */
 
 import crypto from 'crypto';
-export const hash = (x) => crypto.createHash('sha256').update(x, 'utf8').digest('hex');
+
+/**
+ * Password hashing utilities.
+ *
+ * New hashes use scrypt with a per-user random salt and are serialized as
+ * `scrypt$N$r$p$saltHex$hashHex` so that parameters can be evolved later
+ * without breaking existing users.
+ *
+ * Legacy hashes (unsalted SHA-256, produced by prior versions) are still
+ * verifiable via {@link verify}, and {@link needsRehash} returns true for
+ * them so callers can transparently upgrade the stored hash on the next
+ * successful login / password change.
+ */
+
+// scrypt parameters. N must be a power of 2. These defaults follow the
+// current OWASP guidance for interactive login (memory ~ 32 MiB) and stay
+// safely below Node's default `maxmem` of 32 MiB * r * p * 128 headroom
+// (we bump maxmem explicitly to be robust across Node versions).
+const SCRYPT_N = 1 << 15; // 32768
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const KEY_LEN = 64;
+const SALT_LEN = 16;
+const SCRYPT_MAXMEM = 128 * SCRYPT_N * SCRYPT_R * 2; // generous headroom
+
+const SCRYPT_PREFIX = 'scrypt$';
+
+const scryptDerive = (password, salt, N, r, p) =>
+  new Promise((resolve, reject) => {
+    crypto.scrypt(String(password), salt, KEY_LEN, { N, r, p, maxmem: SCRYPT_MAXMEM }, (err, derivedKey) => {
+      if (err) return reject(err);
+      resolve(derivedKey);
+    });
+  });
+
+/**
+ * Hash a password using scrypt with a fresh random salt.
+ * @param {string} password
+ * @returns {Promise<string>} Encoded hash string.
+ */
+export const hash = async (password) => {
+  const salt = crypto.randomBytes(SALT_LEN);
+  const derived = await scryptDerive(password, salt, SCRYPT_N, SCRYPT_R, SCRYPT_P);
+  return `${SCRYPT_PREFIX}${SCRYPT_N}$${SCRYPT_R}$${SCRYPT_P}$${salt.toString('hex')}$${derived.toString('hex')}`;
+};
+
+/**
+ * Verify a plaintext password against a stored hash.
+ * Supports both the current scrypt format and the legacy unsalted SHA-256
+ * hex format used by earlier versions of Fredy.
+ *
+ * @param {string} password - Plaintext password supplied by the user.
+ * @param {string} stored - Hash previously produced by {@link hash} (or a legacy hex SHA-256).
+ * @returns {Promise<boolean>} True when the password matches.
+ */
+export const verify = async (password, stored) => {
+  if (stored == null || typeof stored !== 'string' || stored.length === 0) return false;
+
+  if (stored.startsWith(SCRYPT_PREFIX)) {
+    const parts = stored.slice(SCRYPT_PREFIX.length).split('$');
+    if (parts.length !== 5) return false;
+    const N = Number.parseInt(parts[0], 10);
+    const r = Number.parseInt(parts[1], 10);
+    const p = Number.parseInt(parts[2], 10);
+    if (!Number.isInteger(N) || !Number.isInteger(r) || !Number.isInteger(p) || N <= 1 || r <= 0 || p <= 0) {
+      return false;
+    }
+    let salt;
+    let expected;
+    try {
+      salt = Buffer.from(parts[3], 'hex');
+      expected = Buffer.from(parts[4], 'hex');
+    } catch {
+      return false;
+    }
+    if (salt.length === 0 || expected.length === 0) return false;
+    let derived;
+    try {
+      derived = await scryptDerive(password, salt, N, r, p);
+    } catch {
+      return false;
+    }
+    if (derived.length !== expected.length) return false;
+    return crypto.timingSafeEqual(derived, expected);
+  }
+
+  // Legacy: unsalted SHA-256 hex digest (64 hex chars).
+  if (/^[0-9a-f]{64}$/i.test(stored)) {
+    const candidate = crypto.createHash('sha256').update(String(password), 'utf8').digest('hex');
+    const a = Buffer.from(candidate, 'hex');
+    const b = Buffer.from(stored.toLowerCase(), 'hex');
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+  }
+
+  return false;
+};
+
+/**
+ * Report whether a stored hash should be re-hashed with the current
+ * scheme/parameters. Used to transparently upgrade legacy hashes after a
+ * successful login.
+ * @param {string} stored
+ * @returns {boolean}
+ */
+export const needsRehash = (stored) => {
+  if (typeof stored !== 'string' || stored.length === 0) return true;
+  if (!stored.startsWith(SCRYPT_PREFIX)) return true;
+  const parts = stored.slice(SCRYPT_PREFIX.length).split('$');
+  if (parts.length !== 5) return true;
+  const N = Number.parseInt(parts[0], 10);
+  const r = Number.parseInt(parts[1], 10);
+  const p = Number.parseInt(parts[2], 10);
+  return N < SCRYPT_N || r < SCRYPT_R || p < SCRYPT_P;
+};

--- a/lib/services/storage/userStorage.js
+++ b/lib/services/storage/userStorage.js
@@ -134,7 +134,6 @@ export const removeUser = (userId) => {
   SqliteConnection.execute(`DELETE FROM users WHERE id = @id`, { id: userId });
 };
 
-
 /**
  * Update just the stored password hash for a given user.
  * Used to transparently re-hash legacy (unsalted SHA-256) password digests

--- a/lib/services/storage/userStorage.js
+++ b/lib/services/storage/userStorage.js
@@ -76,7 +76,7 @@ export const getUser = (id) => {
  * @param {boolean} params.isAdmin - Whether the user should have admin privileges.
  * @returns {void}
  */
-export const upsertUser = ({ username, password, userId, isAdmin }) => {
+export const upsertUser = async ({ username, password, userId, isAdmin }) => {
   const id = userId || nanoid();
   // Check if user exists
   const exists = SqliteConnection.query(`SELECT 1 FROM users WHERE id = @id LIMIT 1`, { id }).length > 0;
@@ -85,7 +85,7 @@ export const upsertUser = ({ username, password, userId, isAdmin }) => {
     if (password && password.length > 0) {
       SqliteConnection.execute(
         `UPDATE users SET username = @username, password = @password, is_admin = @is_admin WHERE id = @id`,
-        { id, username, password: hasher.hash(password), is_admin: isAdmin ? 1 : 0 },
+        { id, username, password: await hasher.hash(password), is_admin: isAdmin ? 1 : 0 },
       );
     } else {
       SqliteConnection.execute(`UPDATE users SET username = @username, is_admin = @is_admin WHERE id = @id`, {
@@ -101,7 +101,7 @@ export const upsertUser = ({ username, password, userId, isAdmin }) => {
       {
         id,
         username,
-        password: hasher.hash(password || ''),
+        password: await hasher.hash(password || ''),
         last_login: null,
         is_admin: isAdmin ? 1 : 0,
         mcp_token: generateMcpToken(),
@@ -134,6 +134,22 @@ export const removeUser = (userId) => {
   SqliteConnection.execute(`DELETE FROM users WHERE id = @id`, { id: userId });
 };
 
+
+/**
+ * Update just the stored password hash for a given user.
+ * Used to transparently re-hash legacy (unsalted SHA-256) password digests
+ * after a successful login, without requiring the user to change their password.
+ *
+ * @param {{userId: string, passwordHash: string}} params
+ * @returns {void}
+ */
+export const updatePasswordHash = ({ userId, passwordHash }) => {
+  SqliteConnection.execute(`UPDATE users SET password = @password WHERE id = @id`, {
+    id: userId,
+    password: passwordHash,
+  });
+};
+
 /**
  * Ensure the demo user matches the demo mode setting.
  *
@@ -161,7 +177,7 @@ export const ensureDemoUserExists = async () => {
     SqliteConnection.execute(
       `INSERT INTO users (id, username, password, last_login, is_admin, mcp_token)
        VALUES (@id, 'demo', @password, NULL, 1, @mcp_token)`,
-      { id: nanoid(), password: hasher.hash('demo'), mcp_token: generateMcpToken() },
+      { id: nanoid(), password: await hasher.hash('demo'), mcp_token: generateMcpToken() },
     );
   }
 };
@@ -188,13 +204,13 @@ export const validateMcpToken = (token) => {
   return row ? { userId: row.id } : null;
 };
 
-export const ensureAdminUserExists = () => {
+export const ensureAdminUserExists = async () => {
   const anyUser = SqliteConnection.query(`SELECT id FROM users LIMIT 1`).length > 0;
   if (!anyUser) {
     SqliteConnection.execute(
       `INSERT INTO users (id, username, password, last_login, is_admin, mcp_token)
        VALUES (@id, 'admin', @password, @last_login, 1, @mcp_token)`,
-      { id: nanoid(), password: hasher.hash('admin'), last_login: Date.now(), mcp_token: generateMcpToken() },
+      { id: nanoid(), password: await hasher.hash('admin'), last_login: Date.now(), mcp_token: generateMcpToken() },
     );
     return;
   }

--- a/test/services/hash.test.js
+++ b/test/services/hash.test.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import { hash, verify, needsRehash } from '../../lib/services/security/hash.js';
+
+describe('password hashing (CWE-328)', () => {
+  it('produces salted hashes: two hashes of the same password differ', async () => {
+    const a = await hash('correcthorsebatterystaple');
+    const b = await hash('correcthorsebatterystaple');
+    expect(a).not.toEqual(b);
+    expect(a.startsWith('scrypt$')).toBe(true);
+    expect(b.startsWith('scrypt$')).toBe(true);
+  });
+
+  it('does NOT produce an unsalted SHA-256 hex digest', async () => {
+    const password = 'admin';
+    const sha = crypto.createHash('sha256').update(password, 'utf8').digest('hex');
+    const stored = await hash(password);
+    // The stored form must not equal a plain, rainbow-tableable SHA-256 of the password.
+    expect(stored).not.toEqual(sha);
+    expect(/^[0-9a-f]{64}$/i.test(stored)).toBe(false);
+  });
+
+  it('verify() accepts the correct password and rejects wrong ones', async () => {
+    const stored = await hash('s3cret!');
+    expect(await verify('s3cret!', stored)).toBe(true);
+    expect(await verify('wrong', stored)).toBe(false);
+    expect(await verify('', stored)).toBe(false);
+  });
+
+  it('verify() still accepts legacy unsalted SHA-256 digests (migration path)', async () => {
+    const password = 'legacy-user-password';
+    const legacy = crypto.createHash('sha256').update(password, 'utf8').digest('hex');
+    expect(await verify(password, legacy)).toBe(true);
+    expect(await verify('nope', legacy)).toBe(false);
+    expect(needsRehash(legacy)).toBe(true);
+  });
+
+  it('needsRehash() is false for a freshly produced hash', async () => {
+    const stored = await hash('anything');
+    expect(needsRehash(stored)).toBe(false);
+  });
+
+  it('verify() safely rejects malformed stored values', async () => {
+    expect(await verify('x', null)).toBe(false);
+    expect(await verify('x', '')).toBe(false);
+    expect(await verify('x', 'scrypt$notenoughfields')).toBe(false);
+    expect(await verify('x', 'scrypt$32768$8$1$zz$zz')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fredy currently stores user passwords as **unsalted SHA-256** digests (see `lib/services/security/hash.js` on `master`, which is just `crypto.createHash('sha256').update(password).digest('hex')`). This is CWE-328 (Use of Weak Hash) combined with CWE-916 (Password Hash With Insufficient Computational Effort) and CWE-759 (Missing Salt).

Any time the users table leaks — for example via the admin backup download, a filesystem disclosure, a stolen volume snapshot, or a misconfigured Docker mount — the stored hashes can be reversed in seconds with a precomputed rainbow table, or brute-forced trivially on commodity GPUs (SHA-256 sustains billions of guesses per second). Because self-hosted users often reuse passwords, the practical impact of a users-table leak is credential theft that extends well beyond Fredy itself.

## Fix

`lib/services/security/hash.js` is rewritten to:

- Hash new passwords with **scrypt** (`N=32768, r=8, p=1`, 16-byte random salt, 64-byte key), serialized as `scrypt$N$r$p$saltHex$hashHex` so parameters can be evolved later without a schema change.
- Expose `verify(password, stored)` with constant-time comparison (`crypto.timingSafeEqual`).
- Keep a **legacy branch** in `verify()` that still accepts existing 64-char hex SHA-256 hashes, so no user is locked out on upgrade.
- Add `needsRehash(stored)` — returns `true` for legacy hashes or weaker scrypt parameters.
- In `loginRoute`, on a successful login against a legacy hash, transparently re-hash with the new scheme and persist. No forced password reset, no admin action required — existing installs migrate silently as users log in.

`hash()` and `verify()` are now async; every call site (`index.js`, `generalSettingsRoute`, `loginRoute`, `userRoute`, `userStorage.upsertUser` / `ensureAdminUserExists` / `ensureDemoUserExists`) is updated to `await` them.

## Tests

`test/services/hash.test.js` adds coverage for:

- salt uniqueness (two hashes of the same password differ, and neither is a bare hex digest);
- `verify()` accepts the correct password and rejects a wrong one;
- legacy unsalted SHA-256 hashes still verify (backwards compatibility);
- `needsRehash()` returns `true` for legacy and `false` for freshly-produced hashes;
- malformed / truncated hash strings are rejected without throwing.

`yarn test` passes locally; lint is clean.

## Security analysis

Threat model: an attacker who obtains a copy of the users table (e.g. through the existing admin backup download endpoint, a leaked SQLite file, or a compromised backup). Before this fix, that read-only exposure is sufficient to recover plaintext passwords in minutes. After this fix, scrypt with a per-user salt raises the offline attack cost from "seconds on a laptop" to "computationally infeasible for any reasonable password", which is a genuine capability reduction beyond what the leak precondition alone provides. Timing-safe comparison also removes a theoretical side-channel on the verify path.

### Adversarial review

Before submitting, we tried to disprove this finding. The main counter-arguments we considered were: (1) "the users table is only readable by admins, so leakage is already game-over" — but a leaked backup, stolen disk image, or accidental repo commit are all realistic exposure paths that don't require live admin access, and the shared-password blast radius extends beyond Fredy. (2) "Node/Fastify or the DB layer already provides password protection" — it doesn't; the hashing is entirely in `lib/services/security/hash.js` and was custom SHA-256. (3) "This is just a hardening nit" — CWE-328 with no salt is not a hardening nit; it converts a database read into plaintext credentials. The fix is minimal, backwards compatible, and covered by tests.

## Proof of concept

Reproduce on `master` before the fix:

```js
// node --input-type=module
import crypto from 'crypto';
// This is exactly what lib/services/security/hash.js does on master:
const stored = crypto.createHash('sha256').update('admin').digest('hex');
console.log(stored);
// -> 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
// Google that hex string; the plaintext "admin" is the first hit.
// Same story for any users table exported via the admin backup: every
// row's `password` column is a rainbow-table lookup away from plaintext.
```

After this PR, the stored value looks like `scrypt$32768$8$1$<32 hex salt>$<128 hex hash>`, is unique per user even when passwords collide, and is not present in any rainbow table.

To confirm the migration path end-to-end: start a pre-fix Fredy, create a user, upgrade to this branch, log in with the same password — login succeeds and the stored hash is rewritten to the `scrypt$…` form on that request (observable via a quick `SELECT password FROM users` before and after).