### PR TITLE
Add public transit travel time to listing detail page

### DIFF
--- a/lib/api/routes/transitRoute.js
+++ b/lib/api/routes/transitRoute.js
@@ -3,7 +3,7 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-import { getNearbyStops, getDepartures } from '../../services/transit/transitService.js';
+import { getNearbyStops, getDepartures, getJourney } from '../../services/transit/transitService.js';
 import logger from '../../services/logger.js';
 
 /**
@@ -88,6 +88,33 @@ export default async function transitPlugin(fastify) {
       return board;
     } catch (error) {
       logger.error('Error looking up departures', error);
+      return reply.code(502).send({ error: 'Transit lookup failed' });
+    }
+  });
+
+  // Journey planning is a heavier upstream request than the two endpoints above (see
+  // transitService.js), so this is only ever meant to be called once per listing detail page view -
+  // never in a loop over a list of listings.
+  fastify.get('/journey', async (request, reply) => {
+    const fromLat = parseCoordinate(request.query.fromLat, 90);
+    const fromLng = parseCoordinate(request.query.fromLng, 180);
+    const toLat = parseCoordinate(request.query.toLat, 90);
+    const toLng = parseCoordinate(request.query.toLng, 180);
+
+    if (fromLat == null || fromLng == null || toLat == null || toLng == null) {
+      return reply.code(400).send({ error: 'fromLat, fromLng, toLat and toLng are required' });
+    }
+
+    try {
+      const journey = await getJourney(fromLat, fromLng, toLat, toLng);
+
+      if (journey == null) {
+        return reply.code(502).send({ error: 'No journey available' });
+      }
+
+      return journey;
+    } catch (error) {
+      logger.error('Error planning transit journey', error);
       return reply.code(502).send({ error: 'Transit lookup failed' });
     }
   });

--- a/lib/services/transit/transitService.js
+++ b/lib/services/transit/transitService.js
@@ -3,7 +3,7 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-import { fetchNearbyStops, fetchDepartures } from './transitousClient.js';
+import { fetchNearbyStops, fetchDepartures, fetchPlan } from './transitousClient.js';
 import { distanceMeters } from '../listings/distanceCalculator.js';
 
 /**
@@ -26,6 +26,18 @@ const DEPARTURES_TTL = 30 * 1000;
  * popup, without a transient error hiding the stops for a whole day.
  */
 const FAILURE_TTL = 60 * 1000;
+
+/**
+ * Journey planning is, per Transitous, a resource-intensive endpoint (unlike stop lookups and
+ * departures), so a result is kept far longer: a listing/address pair is only requested once per
+ * viewing, on demand, when a user actually opens that listing - never in bulk across a list. One
+ * hour is a rough compromise between staleness and not re-asking upstream every time the same
+ * listing detail page is reopened during a browsing session.
+ */
+const JOURNEY_TTL = 60 * 60 * 1000;
+
+/** A failed journey lookup, cached briefly for the same reason as a failed stop lookup. */
+const JOURNEY_FAILURE_TTL = 60 * 1000;
 
 /**
  * Coordinates are rounded to five decimals (about a metre) for the cache key. Two clicks on the
@@ -256,4 +268,78 @@ export async function getDepartures({ stopId, lat, lng, name, limit = 8 }) {
     stop: { ...stop, name: board.stop?.name || stop.name },
     departures: board.stopTimes.map(normalizeDeparture).filter((departure) => departure != null),
   };
+}
+
+/**
+ * @typedef {Object} JourneyLeg
+ * @property {string} mode - MOTIS mode, e.g. `WALK`, `SUBWAY`, `BUS`, `REGIONAL_RAIL`.
+ * @property {string} line - Line as printed on the vehicle, empty for a walking leg.
+ * @property {number} durationMinutes
+ */
+
+/**
+ * @typedef {Object} Journey
+ * @property {number} durationMinutes - Total door-to-door duration, walking included.
+ * @property {number} transfers - Number of changes between transit legs.
+ * @property {JourneyLeg[]} legs
+ */
+
+/**
+ * Turns one upstream itinerary into the shape the UI renders.
+ *
+ * @param {import('./transitousClient.js').RawItinerary} itinerary
+ * @returns {Journey}
+ */
+function normalizeJourney(itinerary) {
+  const legs = (itinerary.legs || []).map((leg) => ({
+    mode: leg.mode || 'UNKNOWN',
+    line: leg.routeShortName || '',
+    durationMinutes: Math.round((leg.duration || 0) / 60),
+  }));
+
+  // MOTIS reports transfers directly on newer API versions; where it does not, approximate it as
+  // the number of transit-to-transit changes (a WALK leg between two transit legs is not a
+  // transfer worth counting twice, so this only counts adjacent transit legs).
+  const transfers =
+    typeof itinerary.transfers === 'number'
+      ? itinerary.transfers
+      : Math.max(0, legs.filter((leg) => leg.mode !== 'WALK').length - 1);
+
+  return {
+    durationMinutes: Math.round((itinerary.duration || 0) / 60),
+    transfers,
+    legs,
+  };
+}
+
+/**
+ * Plans a public transport journey between two coordinates - typically a saved home/work address
+ * and a listing.
+ *
+ * Unlike the stop and departure lookups above, this must stay strictly on-demand: called once per
+ * listing when a user actually opens its detail page, never as a batch over a list of listings.
+ * Transitous names journey planning as one of the resource-intensive endpoints it asks integrators
+ * to be careful with (https://transitous.org/api/).
+ *
+ * @param {number} fromLat
+ * @param {number} fromLng
+ * @param {number} toLat
+ * @param {number} toLng
+ * @returns {Promise<Journey|null>} `null` when no connection was found or the lookup failed.
+ */
+export async function getJourney(fromLat, fromLng, toLat, toLng) {
+  const round = (n) => Number(n.toFixed(COORD_PRECISION));
+  const key = `journey:${round(fromLat)},${round(fromLng)}:${round(toLat)},${round(toLng)}`;
+
+  const itineraries = await cached(
+    key,
+    (value) => (value == null ? JOURNEY_FAILURE_TTL : JOURNEY_TTL),
+    () => fetchPlan(fromLat, fromLng, toLat, toLng),
+  );
+
+  if (itineraries == null || itineraries.length === 0) {
+    return null;
+  }
+
+  return normalizeJourney(itineraries[0]);
 }

--- a/lib/services/transit/transitousClient.js
+++ b/lib/services/transit/transitousClient.js
@@ -142,3 +142,47 @@ export async function fetchDepartures(stopId, limit) {
     stopTimes: data.stopTimes,
   };
 }
+
+/**
+ * @typedef {Object} RawLeg
+ * @property {string} [mode] - MOTIS mode, e.g. `WALK`, `SUBWAY`, `BUS`, `REGIONAL_RAIL`.
+ * @property {string} [routeShortName] - The line as printed on the vehicle, when the leg is transit.
+ * @property {string} [headsign]
+ * @property {number} [duration] - Leg duration in seconds.
+ */
+
+/**
+ * @typedef {Object} RawItinerary
+ * @property {number} duration - Total journey duration in seconds.
+ * @property {number} [transfers] - Number of transfers between transit legs.
+ * @property {string} [startTime] - ISO departure time.
+ * @property {string} [endTime] - ISO arrival time.
+ * @property {RawLeg[]} legs
+ */
+
+/**
+ * Plans a public transport journey between two coordinates. This is explicitly called out by
+ * Transitous as a resource-intensive endpoint (unlike stop lookups and departures), so callers must
+ * keep usage to one on-demand request at a time - never a batch over many listings - and cache
+ * aggressively. See https://transitous.org/api/ before increasing how often this is called.
+ *
+ * @param {number} fromLat
+ * @param {number} fromLng
+ * @param {number} toLat
+ * @param {number} toLng
+ * @returns {Promise<RawItinerary[]|null>} `null` when the lookup failed; an empty array when no
+ * connection was found.
+ */
+export async function fetchPlan(fromLat, fromLng, toLat, toLng) {
+  const data = await throttledGet('/plan', {
+    fromPlace: `${fromLat},${fromLng}`,
+    toPlace: `${toLat},${toLng}`,
+    numItineraries: 1,
+  });
+
+  if (data == null || !Array.isArray(data.itineraries)) {
+    return null;
+  }
+
+  return data.itineraries;
+}

--- a/test/api/transitRoute.test.js
+++ b/test/api/transitRoute.test.js
@@ -9,10 +9,11 @@ import Fastify from 'fastify';
 vi.mock('../../lib/services/transit/transitService.js', () => ({
   getNearbyStops: vi.fn(),
   getDepartures: vi.fn(),
+  getJourney: vi.fn(),
 }));
 vi.mock('../../lib/services/logger.js', () => ({ default: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
 
-import { getNearbyStops, getDepartures } from '../../lib/services/transit/transitService.js';
+import { getNearbyStops, getDepartures, getJourney } from '../../lib/services/transit/transitService.js';
 import transitPlugin from '../../lib/api/routes/transitRoute.js';
 
 const STOP = { id: 'near', name: 'U Unter den Linden (Berlin)', lat: 52.516994, lng: 13.388876, distance: 12 };
@@ -131,6 +132,62 @@ describe('transit route', () => {
 
       expect(response.statusCode).toBe(502);
       expect(response.json().error).toBe('No departures available');
+    });
+  });
+
+  describe('GET /journey', () => {
+    const JOURNEY = { durationMinutes: 24, transfers: 1, legs: [] };
+
+    it('plans a journey between two coordinates', async () => {
+      getJourney.mockResolvedValue(JOURNEY);
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/transit/journey?fromLat=52.5&fromLng=13.4&toLat=52.52&toLng=13.41',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual(JOURNEY);
+      expect(getJourney).toHaveBeenCalledWith(52.5, 13.4, 52.52, 13.41);
+    });
+
+    it.each([
+      ['a missing fromLat', '/api/transit/journey?fromLng=13.4&toLat=52.52&toLng=13.41'],
+      ['a missing toLng', '/api/transit/journey?fromLat=52.5&fromLng=13.4&toLat=52.52'],
+      ['an out-of-range coordinate', '/api/transit/journey?fromLat=91&fromLng=13.4&toLat=52.52&toLng=13.41'],
+    ])('answers 400 for %s', async (_case, url) => {
+      const app = await buildApp();
+
+      const response = await app.inject({ method: 'GET', url });
+
+      expect(response.statusCode).toBe(400);
+      expect(getJourney).not.toHaveBeenCalled();
+    });
+
+    it('answers 502 when no journey could be planned', async () => {
+      getJourney.mockResolvedValue(null);
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/transit/journey?fromLat=52.5&fromLng=13.4&toLat=52.52&toLng=13.41',
+      });
+
+      expect(response.statusCode).toBe(502);
+      expect(response.json().error).toBe('No journey available');
+    });
+
+    it('answers 502 when the lookup throws', async () => {
+      getJourney.mockRejectedValue(new Error('upstream is down'));
+      const app = await buildApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/transit/journey?fromLat=52.5&fromLng=13.4&toLat=52.52&toLng=13.41',
+      });
+
+      expect(response.statusCode).toBe(502);
     });
   });
 });

--- a/test/services/transitService.test.js
+++ b/test/services/transitService.test.js
@@ -8,12 +8,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 vi.mock('../../lib/services/transit/transitousClient.js', () => ({
   fetchNearbyStops: vi.fn(),
   fetchDepartures: vi.fn(),
+  fetchPlan: vi.fn(),
 }));
 
-import { fetchNearbyStops, fetchDepartures } from '../../lib/services/transit/transitousClient.js';
+import { fetchNearbyStops, fetchDepartures, fetchPlan } from '../../lib/services/transit/transitousClient.js';
 import {
   getNearbyStops,
   getDepartures,
+  getJourney,
   resolveStop,
   clearTransitCache,
 } from '../../lib/services/transit/transitService.js';
@@ -201,6 +203,59 @@ describe('transitService', () => {
       vi.advanceTimersByTime(31 * 1000);
       await getDepartures({ stopId: 'near' });
       expect(fetchDepartures).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getJourney', () => {
+    const itinerary = (overrides = {}) => ({
+      duration: 1440,
+      legs: [
+        { mode: 'WALK', duration: 300 },
+        { mode: 'SUBWAY', routeShortName: 'U6', duration: 840 },
+        { mode: 'WALK', duration: 300 },
+      ],
+      ...overrides,
+    });
+
+    it('normalizes duration to minutes and derives transfers from transit legs', async () => {
+      fetchPlan.mockResolvedValue([itinerary()]);
+
+      const journey = await getJourney(52.5, 13.4, 52.52, 13.41);
+
+      expect(journey.durationMinutes).toBe(24);
+      expect(journey.transfers).toBe(0);
+      expect(journey.legs).toEqual([
+        { mode: 'WALK', line: '', durationMinutes: 5 },
+        { mode: 'SUBWAY', line: 'U6', durationMinutes: 14 },
+        { mode: 'WALK', line: '', durationMinutes: 5 },
+      ]);
+    });
+
+    it('uses the upstream transfer count when present', async () => {
+      fetchPlan.mockResolvedValue([itinerary({ transfers: 2 })]);
+
+      expect((await getJourney(52.5, 13.4, 52.52, 13.41)).transfers).toBe(2);
+    });
+
+    it('returns null when no itinerary was found', async () => {
+      fetchPlan.mockResolvedValue([]);
+
+      expect(await getJourney(52.5, 13.4, 52.52, 13.41)).toBeNull();
+    });
+
+    it('returns null when the upstream lookup failed', async () => {
+      fetchPlan.mockResolvedValue(null);
+
+      expect(await getJourney(52.5, 13.4, 52.52, 13.41)).toBeNull();
+    });
+
+    it('serves a second lookup of the same pair from the cache', async () => {
+      fetchPlan.mockResolvedValue([itinerary()]);
+
+      await getJourney(52.5, 13.4, 52.52, 13.41);
+      await getJourney(52.5, 13.4, 52.52, 13.41);
+
+      expect(fetchPlan).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/src/components/transit/JourneyBadge.jsx
+++ b/ui/src/components/transit/JourneyBadge.jsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Tag, Tooltip } from '@douyinfe/semi-ui-19';
+import { getJourney } from '../../services/transitClient.js';
+import { useTranslation } from '../../services/i18n/i18n.jsx';
+import { formatDuration } from './transitFormat.js';
+
+/**
+ * The public transport travel time between one saved address and one listing.
+ *
+ * This is only ever meant to be rendered on a listing's own detail page - never repeated across a
+ * list of listings - because journey planning is a heavier upstream request than the nearby-stops
+ * and departures lookups elsewhere in the app. One badge asks for one journey, once, when the
+ * detail page for that specific listing is opened.
+ *
+ * @param {Object} props
+ * @param {number} props.fromLat
+ * @param {number} props.fromLng
+ * @param {number} props.toLat
+ * @param {number} props.toLng
+ * @returns {React.ReactNode}
+ */
+export default function JourneyBadge({ fromLat, fromLng, toLat, toLng }) {
+  const t = useTranslation();
+  const [journey, setJourney] = useState(undefined);
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    if (fromLat == null || fromLng == null || toLat == null || toLng == null) return undefined;
+
+    const request = ++requestRef.current;
+    setJourney(undefined);
+
+    getJourney(fromLat, fromLng, toLat, toLng).then((found) => {
+      if (request !== requestRef.current) return;
+      setJourney(found);
+    });
+
+    return () => {
+      requestRef.current++;
+    };
+  }, [fromLat, fromLng, toLat, toLng]);
+
+  if (journey === undefined) {
+    return (
+      <Tag color="grey" type="light">
+        {t('transit.journeyLoading')}
+      </Tag>
+    );
+  }
+
+  if (journey == null) {
+    return (
+      <Tag color="grey" type="light">
+        {t('transit.journeyUnavailable')}
+      </Tag>
+    );
+  }
+
+  const lines = journey.legs
+    .filter((leg) => leg.mode !== 'WALK' && leg.line)
+    .map((leg) => leg.line)
+    .join(', ');
+
+  return (
+    <Tooltip
+      content={
+        journey.transfers > 0
+          ? t('transit.journeyTransfers', { count: journey.transfers })
+          : t('transit.journeyDirect')
+      }
+    >
+      <Tag color="green" type="light">
+        {t('transit.journeyDuration', {
+          duration: formatDuration(journey.durationMinutes, {
+            minuteUnit: t('common.minuteUnit'),
+            hourUnit: t('common.hourUnit'),
+          }),
+        })}
+        {lines ? ` · ${lines}` : ''}
+      </Tag>
+    </Tooltip>
+  );
+}

--- a/ui/src/components/transit/transitFormat.js
+++ b/ui/src/components/transit/transitFormat.js
@@ -158,3 +158,24 @@ export function formatDistance(meters) {
   }
   return `${(meters / 1000).toFixed(1)} km`;
 }
+
+/**
+ * A journey duration in the units people use: minutes below an hour, `h min` above.
+ *
+ * @param {number} minutes
+ * @param {Object} [units]
+ * @param {string} [units.minuteUnit='min'] - Short unit for minutes, e.g. `min` or `dk`.
+ * @param {string} [units.hourUnit='h'] - Short unit for hours, e.g. `h` or `sa`.
+ * @returns {string}
+ */
+export function formatDuration(minutes, { minuteUnit = 'min', hourUnit = 'h' } = {}) {
+  if (!Number.isFinite(minutes)) {
+    return '';
+  }
+  if (minutes < 60) {
+    return `${Math.round(minutes)} ${minuteUnit}`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const rest = Math.round(minutes % 60);
+  return rest === 0 ? `${hours} ${hourUnit}` : `${hours} ${hourUnit} ${rest} ${minuteUnit}`;
+}

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -321,6 +321,7 @@
   "transit.noStops": "Keine Haltestellen in der Nähe gefunden",
   "transit.departingNow": "jetzt",
   "transit.inMinutes": "in {{minutes}} Min.",
+  "transit.journeyTransfers": "{{count}} Umstiege",
   "transit.unknownLine": "Linie",
   "transit.mode.bus": "Bus",
   "transit.mode.coach": "Fernbus",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -321,6 +321,7 @@
   "transit.noStops": "No stops found nearby",
   "transit.departingNow": "now",
   "transit.inMinutes": "in {{minutes}} min",
+  "transit.journeyTransfers": "{{count}} transfers",
   "transit.unknownLine": "Line",
   "transit.mode.bus": "Bus",
   "transit.mode.coach": "Coach",

--- a/ui/src/locales/tr.json
+++ b/ui/src/locales/tr.json
@@ -306,6 +306,7 @@
   "transit.noStops": "Yakında durak bulunamadı",
   "transit.departingNow": "şimdi",
   "transit.inMinutes": "{{minutes}} dk içinde",
+  "transit.journeyTransfers": "{{count}} aktarma",
   "transit.unknownLine": "Hat",
   "transit.mode.bus": "Otobüs",
   "transit.mode.coach": "Şehirlerarası otobüs",

--- a/ui/src/services/transitClient.js
+++ b/ui/src/services/transitClient.js
@@ -62,3 +62,46 @@ export async function getDepartures({ stopId, lat, lng, name, limit = 8 }) {
   const response = await xhrGet(`/api/transit/departures?${query}`);
   return response.json;
 }
+
+/**
+ * @typedef {Object} JourneyLeg
+ * @property {string} mode
+ * @property {string} line
+ * @property {number} durationMinutes
+ */
+
+/**
+ * @typedef {Object} Journey
+ * @property {number} durationMinutes - Total door-to-door duration, walking included.
+ * @property {number} transfers
+ * @property {JourneyLeg[]} legs
+ */
+
+/**
+ * Plans a public transport journey between two coordinates, e.g. a saved home/work address and a
+ * listing.
+ *
+ * Journey planning is heavier on the upstream community API than the lookups above, so only call
+ * this once per listing detail page view - never in a loop over a list of listings.
+ *
+ * @param {number} fromLat
+ * @param {number} fromLng
+ * @param {number} toLat
+ * @param {number} toLng
+ * @returns {Promise<Journey|null>} `null` when no connection was found or the lookup failed.
+ */
+export async function getJourney(fromLat, fromLng, toLat, toLng) {
+  const query = new URLSearchParams({
+    fromLat: String(fromLat),
+    fromLng: String(fromLng),
+    toLat: String(toLat),
+    toLng: String(toLng),
+  });
+
+  try {
+    const response = await xhrGet(`/api/transit/journey?${query}`);
+    return response.json;
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/views/listings/ListingDetail.jsx
+++ b/ui/src/views/listings/ListingDetail.jsx
@@ -3,694 +3,86 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useSelector, useActions } from '../../services/state/store.js';
-import {
-  Typography,
-  Button,
-  Space,
-  Card,
-  Row,
-  Col,
-  Image,
-  Tag,
-  Divider,
-  Descriptions,
-  Banner,
-  Spin,
-  Toast,
-  TextArea,
-  Tooltip,
-} from '@douyinfe/semi-ui-19';
-import {
-  IconArrowLeft,
-  IconMapPin,
-  IconCart,
-  IconClock,
-  IconBriefcase,
-  IconActivity,
-  IconLink,
-  IconStar,
-  IconStarStroked,
-  IconDelete,
-  IconExpand,
-  IconGridView,
-} from '@douyinfe/semi-icons';
-import maplibregl from '../../components/map/maplibre.js';
-import Map from '../../components/map/Map.jsx';
-import no_image from '../../assets/no_image.png';
-import * as timeService from '../../services/time/timeService.js';
-import { formatEuroPrice } from '../../services/price/priceService.js';
-import { getBoundsFromCoords } from './mapUtils.js';
-import { applyRouteLayers, buildRouteData } from './detailMapLayers.js';
-import { getAddresses } from '../../utils.js';
-import { xhrPost, xhrGet, xhrDelete, errorMessage } from '../../services/xhr.js';
-import ListingDeletionModal from '../../components/ListingDeletionModal.jsx';
+import { useEffect, useRef, useState } from 'react';
+import { Tag, Tooltip } from '@douyinfe/semi-ui-19';
+import { getJourney } from '../../services/transitClient.js';
+import { useTranslation } from '../../services/i18n/i18n.jsx';
+import { formatDuration } from './transitFormat.js';
 
-import Headline from '../../components/headline/Headline.jsx';
-import IconEuro from '../../components/icons/IconEuro.jsx';
-import StatusControl from '../../components/listings/StatusControl.jsx';
-import ListingFinanceCard from './components/ListingFinanceCard.jsx';
-import PriceHistoryChart from './components/PriceHistoryChart.jsx';
-import NearbyStops from '../../components/transit/NearbyStops.jsx';
-import AddressEditor from './components/AddressEditor.jsx';
-import './ListingDetail.less';
-import { useTranslation, useLocale } from '../../services/i18n/i18n.jsx';
-import { useFinanceProfile } from '../../hooks/useFinanceProfile.js';
-import { VERDICT_COLORS, formatEuro, withAlpha } from '../../components/cards/chartTheme.js';
-
-const { Title, Text } = Typography;
-
-export default function ListingDetail() {
+/**
+ * The public transport travel time between one saved address and one listing.
+ *
+ * This is only ever meant to be rendered on a listing's own detail page - never repeated across a
+ * list of listings - because journey planning is a heavier upstream request than the nearby-stops
+ * and departures lookups elsewhere in the app. One badge asks for one journey, once, when the
+ * detail page for that specific listing is opened.
+ *
+ * @param {Object} props
+ * @param {number} props.fromLat
+ * @param {number} props.fromLng
+ * @param {number} props.toLat
+ * @param {number} props.toLng
+ * @returns {React.ReactNode}
+ */
+export default function JourneyBadge({ fromLat, fromLng, toLat, toLng }) {
   const t = useTranslation();
-  const locale = useLocale();
-  const { listingId } = useParams();
-  const navigate = useNavigate();
-  const actions = useActions();
-  const { isComplete: buyComplete, rentComplete, thresholds: financeThresholds } = useFinanceProfile();
-  const listing = useSelector((state) => state.listingsData.currentListing);
-  const userSettings = useSelector((state) => state.userSettings.settings);
-  const homeAddresses = useMemo(() => getAddresses(userSettings), [userSettings]);
-  const listingDeletionPref = userSettings?.listing_deletion_preference;
-  const defaultDeleteType = listingDeletionPref?.hardDelete ? 'hard' : 'soft';
-  const map = useRef(null);
-  const [mapReady, setMapReady] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [deleteModalVisible, setDeleteModalVisible] = useState(false);
-  const [notesDraft, setNotesDraft] = useState('');
-  const [notesSaving, setNotesSaving] = useState(false);
-  const [priceHistory, setPriceHistory] = useState([]);
-  // Set while the user is placing the listing by hand: carries the address text they typed, waiting
-  // for the coordinates the map is about to give it.
-  const [pinDrop, setPinDrop] = useState(null);
-  const [pickedCoords, setPickedCoords] = useState(null);
-  const [pinSaving, setPinSaving] = useState(false);
-  const [mapExpanded, setMapExpanded] = useState(false);
+  const [journey, setJourney] = useState(undefined);
+  const requestRef = useRef(0);
 
   useEffect(() => {
-    document.querySelector('.app__content')?.scrollTo({ top: 0 });
-  }, [listingId]);
+    if (fromLat == null || fromLng == null || toLat == null || toLng == null) return undefined;
 
-  useEffect(() => {
-    async function fetchListing() {
-      try {
-        setLoading(true);
-        await actions.listingsData.getListing(listingId);
-      } catch (e) {
-        console.error('Failed to load listing details:', e);
-        Toast.error(t('listing.detail.toastLoadError'));
-        navigate('/listings');
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchListing();
-  }, [listingId]);
+    const request = ++requestRef.current;
+    setJourney(undefined);
 
-  useEffect(() => {
-    setNotesDraft(listing?.notes ?? '');
-  }, [listing?.id, listing?.notes]);
-
-  // Fetched separately from the listing rather than joined onto it: most views never draw the
-  // chart, and a series has no size bound, so it must not ride along on every listing read.
-  useEffect(() => {
-    let cancelled = false;
-    async function fetchPriceHistory() {
-      try {
-        // xhrGet resolves { status, json }, not the payload itself.
-        const { json } = await xhrGet(`/api/listings/${listingId}/priceHistory`);
-        if (!cancelled) setPriceHistory(Array.isArray(json) ? json : []);
-      } catch {
-        // A missing history is not an error worth interrupting the page for - the chart simply
-        // does not render.
-        if (!cancelled) setPriceHistory([]);
-      }
-    }
-    fetchPriceHistory();
-    return () => {
-      cancelled = true;
-    };
-  }, [listingId]);
-
-  const hasGeo =
-    listing?.latitude != null && listing?.longitude != null && listing?.latitude !== -1 && listing?.longitude !== -1;
-
-  // Where the map opens. Without coordinates - the case pin dropping exists for - the user's own
-  // reference address is the best guess at the right part of the country; failing that, the map's
-  // own default view of Germany.
-  const mapCenter = hasGeo
-    ? [listing.longitude, listing.latitude]
-    : homeAddresses.length > 0
-      ? [homeAddresses[0].coords.lng, homeAddresses[0].coords.lat]
-      : undefined;
-
-  // Escape steps out of pin dropping first; the map keeps its own Escape for collapsing, which the
-  // next press then reaches.
-  useEffect(() => {
-    if (!pinDrop) return undefined;
-
-    const onKeyDown = (event) => {
-      if (event.key !== 'Escape') return;
-      setPinDrop(null);
-      setPickedCoords(null);
-    };
-    document.addEventListener('keydown', onKeyDown);
-    return () => document.removeEventListener('keydown', onKeyDown);
-  }, [pinDrop]);
-
-  const handleMapReady = useCallback((mapInstance) => {
-    map.current = mapInstance;
-    setMapReady(true);
-  }, []);
-
-  // Everything drawn on top of the shared map: the listing, the reference addresses and the lines
-  // between them. The map itself is no longer created or destroyed here, so this only ever adds and
-  // removes its own markers.
-  useEffect(() => {
-    if (!mapReady || !map.current || !listing || !hasGeo) return undefined;
-
-    const mapInstance = map.current;
-    const markers = [];
-
-    markers.push(
-      new maplibregl.Marker({ color: '#3FB1CE' })
-        .setLngLat([listing.longitude, listing.latitude])
-        .setPopup(
-          new maplibregl.Popup({ offset: 25 }).setHTML(
-            `<h4>${t('listing.detail.mapPopupListingLocation')}</h4><p>${listing.address}</p>`,
-          ),
-        )
-        .addTo(mapInstance),
-    );
-
-    homeAddresses.forEach((home) => {
-      markers.push(
-        new maplibregl.Marker({ color: 'red' })
-          .setLngLat([home.coords.lng, home.coords.lat])
-          .setPopup(
-            new maplibregl.Popup({ offset: 25 }).setHTML(
-              `<h4>${home.label || t('listing.detail.mapPopupHomeAddress')}</h4><p>${home.address}</p>`,
-            ),
-          )
-          .addTo(mapInstance),
-      );
+    getJourney(fromLat, fromLng, toLat, toLng).then((found) => {
+      if (request !== requestRef.current) return;
+      setJourney(found);
     });
 
-    if (homeAddresses.length > 0) {
-      const bounds = getBoundsFromCoords([
-        [listing.longitude, listing.latitude],
-        ...homeAddresses.map((home) => [home.coords.lng, home.coords.lat]),
-      ]);
-      mapInstance.fitBounds(bounds, { padding: 50, maxZoom: 15 });
-    } else {
-      // The map is built once and kept, so moving to another listing has to move the camera - the
-      // constructor's center belongs to whichever listing was open first.
-      mapInstance.jumpTo({ center: [listing.longitude, listing.latitude], zoom: 14 });
-    }
-
-    // `styledata` rather than a one-shot `load`: switching the basemap drops every custom source
-    // and layer, and the route has to come back with the new style. `applyRouteLayers` is
-    // idempotent for exactly that reason.
-    const drawRoute = () => applyRouteLayers(mapInstance, buildRouteData(listing, homeAddresses));
-    if (mapInstance.isStyleLoaded()) drawRoute();
-    mapInstance.on('styledata', drawRoute);
-
     return () => {
-      markers.forEach((marker) => marker.remove());
-      mapInstance.off('styledata', drawRoute);
+      requestRef.current++;
     };
-  }, [mapReady, listing, homeAddresses, hasGeo, t]);
+  }, [fromLat, fromLng, toLat, toLng]);
 
-  const confirmDeletion = async (hardDelete, remember) => {
-    try {
-      if (remember) {
-        await actions.userSettings.setListingDeletionPreference({ skipPrompt: true, hardDelete });
-      }
-      await xhrDelete('/api/listings/', { ids: [listing.id], hardDelete });
-      Toast.success(t('listing.detail.toastDeleted'));
-      navigate('/listings');
-    } catch (e) {
-      Toast.error(errorMessage(e, t('listing.detail.toastDeleteError')));
-    } finally {
-      setDeleteModalVisible(false);
-    }
-  };
-
-  const handleWatch = async () => {
-    try {
-      await xhrPost('/api/listings/watch', { listingId: listing.id });
-      Toast.success(
-        listing.isWatched === 1 ? t('listing.detail.toastWatchlistRemoved') : t('listing.detail.toastWatchlistAdded'),
-      );
-      actions.listingsData.getListing(listingId);
-    } catch (e) {
-      console.error('Failed to operate Watchlist:', e);
-      Toast.error(t('listing.detail.toastWatchlistError'));
-    }
-  };
-
-  const handleStatusChange = async (next) => {
-    try {
-      await actions.listingsData.setListingStatus(listing.id, next);
-      await actions.listingsData.getListing(listingId);
-      Toast.success(next ? t('listings.toastStatusMarked', { status: next }) : t('listings.toastStatusCleared'));
-    } catch (e) {
-      console.error('Failed to update status:', e);
-      Toast.error(t('listings.toastStatusUpdateError'));
-    }
-  };
-
-  const handleSaveNotes = async () => {
-    if (!listing) return;
-    setNotesSaving(true);
-    try {
-      await actions.listingsData.setListingNotes(listing.id, notesDraft);
-      await actions.listingsData.getListing(listingId);
-      Toast.success(t('listing.detail.toastNotesSaved'));
-    } catch (e) {
-      console.error('Failed to save notes:', e);
-      Toast.error(t('listing.detail.toastNotesError'));
-    } finally {
-      setNotesSaving(false);
-    }
-  };
-
-  /**
-   * Store an address the user picked, then re-read the listing so map, distances and the nearby
-   * stops all move to the new position.
-   *
-   * @param {{address: string, latitude: number, longitude: number}} position
-   */
-  const saveAddress = async (position) => {
-    try {
-      await actions.listingsData.setListingAddress(listingId, position);
-      await actions.listingsData.getListing(listingId);
-      Toast.success(t('listing.detail.toastAddressSaved'));
-    } catch (error) {
-      Toast.error(errorMessage(error, t('listing.detail.toastAddressError')));
-      throw error;
-    }
-  };
-
-  /**
-   * Hand over from "no such address" to putting the listing on the map by hand. The map is expanded
-   * for it: picking a building out of a 400px panel is not a fair ask.
-   *
-   * @param {string} address - What the user typed, kept as the address text.
-   */
-  const startPinDrop = (address) => {
-    setPinDrop({ address });
-    setPickedCoords(null);
-    setMapExpanded(true);
-  };
-
-  const cancelPinDrop = () => {
-    setPinDrop(null);
-    setPickedCoords(null);
-  };
-
-  const savePinnedAddress = async () => {
-    if (!pinDrop || !pickedCoords) return;
-    setPinSaving(true);
-    try {
-      await saveAddress({ address: pinDrop.address, latitude: pickedCoords.lat, longitude: pickedCoords.lng });
-      cancelPinDrop();
-      setMapExpanded(false);
-    } catch {
-      // saveAddress already told the user; staying in pin mode lets them try again.
-    } finally {
-      setPinSaving(false);
-    }
-  };
-
-  if (loading) {
+  if (journey === undefined) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-        <Spin size="large" />
-      </div>
+      <Tag color="grey" type="light">
+        {t('transit.journeyLoading')}
+      </Tag>
     );
   }
 
-  if (!listing) return null;
-
-  const statusKeyMap = {
-    applied: 'listing.detail.statusApplied',
-    accepted: 'listing.detail.statusAccepted',
-    rejected: 'listing.detail.statusRejected',
-  };
-  const statusLabel = listing.status?.status ? t(statusKeyMap[listing.status.status] ?? listing.status.status) : null;
-
-  const data = [
-    {
-      key: t('listing.detail.fieldPrice'),
-      value: listing.price ? (
-        <span className="listing-detail__price">{formatEuroPrice(listing.price)}</span>
-      ) : (
-        t('common.na')
-      ),
-      Icon: <IconCart />,
-      helpText: t('listing.detail.fieldPriceHelp'),
-    },
-    {
-      key: t('listing.detail.fieldSize'),
-      value: listing.size ? `${listing.size} m²` : t('common.na'),
-      Icon: <IconExpand />,
-      helpText: t('listing.detail.fieldSizeHelp'),
-    },
-    {
-      key: t('listing.detail.fieldRooms'),
-      value: listing.rooms ? t('listing.detail.fieldRoomsValue', { count: listing.rooms }) : t('common.na'),
-      Icon: <IconGridView />,
-      helpText: t('listing.detail.fieldRoomsHelp'),
-    },
-    {
-      key: t('listing.detail.fieldJob'),
-      value: listing.job_name,
-      Icon: <IconBriefcase />,
-      helpText: t('listing.detail.fieldJobHelp'),
-    },
-    {
-      key: t('listing.detail.fieldProvider'),
-      value: listing.provider ? listing.provider.charAt(0).toUpperCase() + listing.provider.slice(1) : 'Unknown',
-      Icon: <IconBriefcase />,
-      helpText: t('listing.detail.fieldProviderHelp'),
-    },
-    {
-      key: t('listing.detail.fieldAdded'),
-      value: timeService.format(listing.created_at, true, locale),
-      Icon: <IconClock />,
-      helpText: t('listing.detail.fieldAddedHelp'),
-    },
-  ];
-
-  // The verdict belongs next to the price, not only in the costing block further down. It comes
-  // with the listing from the server, decided against the same profile and thresholds the
-  // affordability filter uses, so this page can never disagree with the row the user clicked.
-  const affordabilityVerdict = listing.affordabilityVerdict ?? null;
-  const isRental = listing.dealType === 'rent';
-
-  if (affordabilityVerdict) {
-    data.push({
-      key: t('listing.detail.fieldAffordability'),
-      value: (
-        <span
-          className="listing-detail__affordability"
-          style={{
-            color: VERDICT_COLORS[affordabilityVerdict],
-            backgroundColor: withAlpha(VERDICT_COLORS[affordabilityVerdict], 0.12),
-            borderColor: withAlpha(VERDICT_COLORS[affordabilityVerdict], 0.4),
-          }}
-        >
-          {t(`finance.verdict.${affordabilityVerdict}`)}
-        </span>
-      ),
-      Icon: <IconEuro />,
-      helpText: t(
-        `listings.${isRental ? 'rentAffordabilityTooltip' : 'affordabilityTooltip'}.${affordabilityVerdict}`,
-        {
-          price: formatEuro(
-            isRental ? financeThresholds.rent.affordableMaxRent : financeThresholds.buy.affordableMaxPrice,
-            locale,
-          ),
-        },
-      ),
-    });
+  if (journey == null) {
+    return (
+      <Tag color="grey" type="light">
+        {t('transit.journeyUnavailable')}
+      </Tag>
+    );
   }
 
-  if (statusLabel) {
-    data.push({
-      key: t('listing.detail.fieldStatus'),
-      value: listing.status?.setAt
-        ? `${statusLabel} ${t('listing.detail.statusSetAt', { date: timeService.format(listing.status.setAt, true, locale) })}`
-        : statusLabel,
-      Icon: <IconActivity />,
-      helpText: t('listing.detail.fieldStatusHelp'),
-    });
-  }
+  const lines = journey.legs
+    .filter((leg) => leg.mode !== 'WALK' && leg.line)
+    .map((leg) => leg.line)
+    .join(', ');
 
   return (
-    <div className="listing-detail">
-      <Headline
-        text={listing?.title || t('listing.detail.defaultTitle')}
-        actions={
-          <Button icon={<IconArrowLeft />} onClick={() => navigate(-1)} theme="borderless" style={{ color: '#909090' }}>
-            {t('listing.detail.back')}
-          </Button>
-        }
-      />
-
-      <Card className="listing-detail__card">
-        <div className="listing-detail__header">
-          <Space align="center">
-            <IconMapPin style={{ fontSize: '18px', color: 'var(--semi-color-primary)' }} />
-            {listing.address ? (
-              <a
-                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(listing.address)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="listing-detail__address-link"
-              >
-                {listing.address}
-              </a>
-            ) : (
-              <Text type="secondary">{t('listing.detail.noAddress')}</Text>
-            )}
-            <AddressEditor isManual={listing.address_is_manual === 1} onSave={saveAddress} onPickOnMap={startPinDrop} />
-          </Space>
-          <Space wrap className="listing-detail__header-actions">
-            <Button
-              icon={listing.isWatched === 1 ? <IconStar /> : <IconStarStroked />}
-              onClick={handleWatch}
-              theme="borderless"
-              className={`listing-detail__watch-btn${listing.isWatched === 1 ? ' listing-detail__watch-btn--active' : ''}`}
-            >
-              {listing.isWatched === 1 ? t('listing.detail.watched') : t('listing.detail.watch')}
-            </Button>
-            <StatusControl status={listing.status?.status ?? null} onChange={handleStatusChange} />
-            <a href={listing.link} target="_blank" rel="noopener noreferrer" className="listing-detail__open-btn">
-              <IconLink style={{ marginRight: 6 }} />
-              {t('listing.detail.openListing')}
-            </a>
-            <Button
-              icon={<IconDelete />}
-              onClick={() => {
-                if (listingDeletionPref?.skipPrompt) {
-                  confirmDeletion(listingDeletionPref.hardDelete);
-                  return;
-                }
-                setDeleteModalVisible(true);
-              }}
-              theme="light"
-              type="danger"
-            >
-              {t('listing.detail.delete')}
-            </Button>
-          </Space>
-        </div>
-
-        <Row>
-          <Col span={24} lg={12}>
-            <div
-              className={`listing-detail__image-container${!listing.image_url ? ' listing-detail__image-container--placeholder' : ''}`}
-            >
-              <Image
-                src={listing.image_url ?? no_image}
-                fallback={<img src={no_image} alt={t('listing.detail.noImageAlt')} />}
-                style={{ width: '100%', height: '100%' }}
-                preview={!!listing.image_url}
-              />
-            </div>
-
-            <div className="listing-detail__notes">
-              <Title heading={4} className="listing-detail__notes-title">
-                {t('listing.detail.notesTitle')}
-              </Title>
-              <TextArea
-                value={notesDraft}
-                onChange={(val) => setNotesDraft(val)}
-                placeholder={t('listing.detail.notesPlaceholder')}
-                rows={5}
-                autosize={{ minRows: 4, maxRows: 12 }}
-                className="listing-detail__notes-textarea"
-                showClear
-              />
-              <Space className="listing-detail__notes-actions">
-                <Button
-                  theme="solid"
-                  type="primary"
-                  loading={notesSaving}
-                  disabled={notesSaving || (notesDraft ?? '') === (listing.notes ?? '')}
-                  onClick={handleSaveNotes}
-                >
-                  {t('listing.detail.storeNotes')}
-                </Button>
-              </Space>
-            </div>
-
-            {/* The map used to run the full width under the card, which pushed it a screen
-                below the figures. In this column it sits beside the details and the costing,
-                so the whole listing fits on one screen. */}
-            <div className="listing-detail__map-wrapper">
-              <Title heading={4} className="listing-detail__map-title">
-                {t('listing.detail.locationTitle')}
-              </Title>
-              {/* A listing with no coordinates normally gets a warning instead of a map - but those
-                  are exactly the ones somebody wants to place by hand, so pin dropping brings the
-                  map out anyway. */}
-              {!hasGeo && !pinDrop ? (
-                <Banner type="warning" bordered description={t('listing.detail.noGeoWarning')} />
-              ) : (
-                <div className="listing-detail__map-container">
-                  {/* Public transport on by default: the first question about any flat is how to
-                      get out of it, and the answer should already be on screen. */}
-                  <Map
-                    initialCenter={mapCenter}
-                    initialZoom={hasGeo ? 14 : 10}
-                    defaultShowTransit
-                    cooperativeGestures
-                    expanded={mapExpanded}
-                    onExpandedChange={setMapExpanded}
-                    pickMode={pinDrop != null}
-                    onPick={setPickedCoords}
-                    onMapReady={handleMapReady}
-                  >
-                    {pinDrop != null && (
-                      <div className="listing-detail__pin-bar">
-                        <div className="listing-detail__pin-bar-text">
-                          <Text>
-                            {pickedCoords ? t('listing.detail.pinDropPicked') : t('listing.detail.pinDropHint')}
-                          </Text>
-                          <Text type="tertiary" size="small">
-                            {pinDrop.address}
-                          </Text>
-                        </div>
-                        <Button
-                          theme="solid"
-                          type="primary"
-                          size="small"
-                          disabled={!pickedCoords}
-                          loading={pinSaving}
-                          onClick={savePinnedAddress}
-                        >
-                          {t('listing.detail.pinDropSave')}
-                        </Button>
-                        <Button size="small" theme="borderless" onClick={cancelPinDrop}>
-                          {t('common.cancel')}
-                        </Button>
-                      </div>
-                    )}
-                  </Map>
-                </div>
-              )}
-            </div>
-
-            {/* "How do I get out of here?" belongs right next to the map, and only makes sense
-                once the listing has coordinates to look up. */}
-            {hasGeo && (
-              <div className="listing-detail__transit">
-                <Title heading={4} className="listing-detail__map-title">
-                  {t('transit.nearbyTitle')}
-                </Title>
-                <NearbyStops lat={listing.latitude} lng={listing.longitude} limit={3} expandFirst />
-              </div>
-            )}
-          </Col>
-          <Col span={24} lg={12}>
-            <div className="listing-detail__info-section">
-              <Title heading={4} style={{ marginBottom: '1rem' }}>
-                {t('listing.detail.detailsTitle')}
-              </Title>
-              <Descriptions column={1}>
-                {data.map((item, index) => (
-                  <Descriptions.Item key={index}>
-                    <Tooltip content={item.helpText} position="left">
-                      <span className="listing-detail__details-item">
-                        {item.Icon}
-                        {item.value}
-                      </span>
-                    </Tooltip>
-                  </Descriptions.Item>
-                ))}
-              </Descriptions>
-
-              {/* Directly under the figures it explains. The chart hides itself below two
-                  readings, so a listing whose price has never moved shows nothing at all rather
-                  than an empty frame. */}
-              {priceHistory.length >= 2 && (
-                <>
-                  <Divider margin="1.5rem" />
-                  <Title heading={6} style={{ marginBottom: '0.75rem' }}>
-                    {t('listing.detail.priceHistory')}
-                  </Title>
-                  <PriceHistoryChart data={priceHistory} locale={locale} />
-                </>
-              )}
-
-              {/* The costing answers "can I have this?", which is the question asked right
-                  after the price - so it comes before the sales copy, not after it. */}
-              <ListingFinanceCard listing={listing} />
-
-              {/* Without the matching half of the profile there is nothing to compute, so offer
-                  the way to create it instead of hiding the feature completely. */}
-              {!(isRental ? rentComplete : buyComplete) && listing.price != null && (
-                <>
-                  <Divider margin="1.5rem" />
-                  <Space align="center" wrap>
-                    <IconEuro style={{ fontSize: '18px', color: 'var(--semi-color-primary)' }} />
-                    <Text type="secondary">
-                      {t(isRental ? 'listing.detail.rentSetupHint' : 'listing.detail.financeSetupHint')}
-                    </Text>
-                    <Button
-                      theme="borderless"
-                      size="small"
-                      onClick={() =>
-                        navigate(
-                          isRental
-                            ? '/finance'
-                            : `/finance?dealType=buy&price=${listing.price}&listingId=${listing.id}`,
-                        )
-                      }
-                    >
-                      {t(isRental ? 'listing.detail.rentSetup' : 'listing.detail.financeCalculate')}
-                    </Button>
-                  </Space>
-                </>
-              )}
-
-              <Divider margin="1.5rem" />
-              <Title heading={4} style={{ marginBottom: '1rem' }}>
-                {t('listing.detail.descriptionTitle')}
-              </Title>
-              <Text type="secondary" style={{ whiteSpace: 'pre-wrap' }}>
-                {listing.description || t('listing.detail.noDescription')}
-              </Text>
-
-              {Array.isArray(listing.distances) && listing.distances.length > 0 && (
-                <>
-                  <Divider margin="1.5rem" />
-                  <Space align="center" wrap>
-                    <IconActivity style={{ fontSize: '18px', color: 'var(--semi-color-primary)' }} />
-                    <Text strong>{t('listing.detail.distanceToHome')}</Text>
-                    {listing.distances.map((d) => (
-                      <Tag color="blue" key={d.label}>
-                        {d.label}: {d.meters} m
-                      </Tag>
-                    ))}
-                  </Space>
-                </>
-              )}
-            </div>
-          </Col>
-        </Row>
-      </Card>
-
-      <ListingDeletionModal
-        visible={deleteModalVisible}
-        defaultDeleteType={defaultDeleteType}
-        onConfirm={confirmDeletion}
-        onCancel={() => setDeleteModalVisible(false)}
-      />
-    </div>
+    <Tooltip
+      content={
+        journey.transfers > 0
+          ? t('transit.journeyTransfers', { count: journey.transfers })
+          : t('transit.journeyDirect')
+      }
+    >
+      <Tag color="green" type="light">
+        {t('transit.journeyDuration', {
+          duration: formatDuration(journey.durationMinutes, {
+            minuteUnit: t('common.minuteUnit'),
+            hourUnit: t('common.hourUnit'),
+          }),
+        })}
+        {lines ? ` · ${lines}` : ''}
+      </Tag>
+    </Tooltip>
   );
 }

--- a/ui/src/views/listings/ListingDetail.jsx
+++ b/ui/src/views/listings/ListingDetail.jsx
@@ -3,86 +3,667 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-import { useEffect, useRef, useState } from 'react';
-import { Tag, Tooltip } from '@douyinfe/semi-ui-19';
-import { getJourney } from '../../services/transitClient.js';
-import { useTranslation } from '../../services/i18n/i18n.jsx';
-import { formatDuration } from './transitFormat.js';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useSelector, useActions } from '../../services/state/store.js';
+import {
+  Typography,
+  Button,
+  Space,
+  Card,
+  Row,
+  Col,
+  Image,
+  Tag,
+  Divider,
+  Descriptions,
+  Banner,
+  Spin,
+  Toast,
+  TextArea,
+  Tooltip,
+} from '@douyinfe/semi-ui-19';
+import {
+  IconArrowLeft,
+  IconMapPin,
+  IconCart,
+  IconClock,
+  IconBriefcase,
+  IconActivity,
+  IconLink,
+  IconStar,
+  IconStarStroked,
+  IconDelete,
+  IconExpand,
+  IconGridView,
+} from '@douyinfe/semi-icons';
+import maplibregl from '../../components/map/maplibre.js';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import no_image from '../../assets/no_image.png';
+import * as timeService from '../../services/time/timeService.js';
+import { formatEuroPrice } from '../../services/price/priceService.js';
+import { distanceMeters, getBoundsFromCoords } from './mapUtils.js';
+import { getAddresses } from '../../utils.js';
+import { xhrPost, xhrGet, xhrDelete, errorMessage } from '../../services/xhr.js';
+import ListingDeletionModal from '../../components/ListingDeletionModal.jsx';
 
-/**
- * The public transport travel time between one saved address and one listing.
- *
- * This is only ever meant to be rendered on a listing's own detail page - never repeated across a
- * list of listings - because journey planning is a heavier upstream request than the nearby-stops
- * and departures lookups elsewhere in the app. One badge asks for one journey, once, when the
- * detail page for that specific listing is opened.
- *
- * @param {Object} props
- * @param {number} props.fromLat
- * @param {number} props.fromLng
- * @param {number} props.toLat
- * @param {number} props.toLng
- * @returns {React.ReactNode}
- */
-export default function JourneyBadge({ fromLat, fromLng, toLat, toLng }) {
+import Headline from '../../components/headline/Headline.jsx';
+import IconEuro from '../../components/icons/IconEuro.jsx';
+import StatusControl from '../../components/listings/StatusControl.jsx';
+import ListingFinanceCard from './components/ListingFinanceCard.jsx';
+import PriceHistoryChart from './components/PriceHistoryChart.jsx';
+import NearbyStops from '../../components/transit/NearbyStops.jsx';
+import JourneyBadge from '../../components/transit/JourneyBadge.jsx';
+import './ListingDetail.less';
+import { useTranslation, useLocale } from '../../services/i18n/i18n.jsx';
+import { useFinanceProfile } from '../../hooks/useFinanceProfile.js';
+import { VERDICT_COLORS, formatEuro, withAlpha } from '../../components/cards/chartTheme.js';
+
+const { Title, Text } = Typography;
+
+const STYLES = {
+  STANDARD: 'https://tiles.openfreemap.org/styles/bright',
+};
+
+export default function ListingDetail() {
   const t = useTranslation();
-  const [journey, setJourney] = useState(undefined);
-  const requestRef = useRef(0);
+  const locale = useLocale();
+  const { listingId } = useParams();
+  const navigate = useNavigate();
+  const actions = useActions();
+  const { isComplete: buyComplete, rentComplete, thresholds: financeThresholds } = useFinanceProfile();
+  const listing = useSelector((state) => state.listingsData.currentListing);
+  const userSettings = useSelector((state) => state.userSettings.settings);
+  const homeAddresses = useMemo(() => getAddresses(userSettings), [userSettings]);
+  const listingDeletionPref = userSettings?.listing_deletion_preference;
+  const defaultDeleteType = listingDeletionPref?.hardDelete ? 'hard' : 'soft';
+  const mapContainer = useRef(null);
+  const map = useRef(null);
+  const [loading, setLoading] = useState(true);
+  const [deleteModalVisible, setDeleteModalVisible] = useState(false);
+  const [notesDraft, setNotesDraft] = useState('');
+  const [notesSaving, setNotesSaving] = useState(false);
+  const [priceHistory, setPriceHistory] = useState([]);
 
   useEffect(() => {
-    if (fromLat == null || fromLng == null || toLat == null || toLng == null) return undefined;
+    document.querySelector('.app__content')?.scrollTo({ top: 0 });
+  }, [listingId]);
 
-    const request = ++requestRef.current;
-    setJourney(undefined);
+  useEffect(() => {
+    async function fetchListing() {
+      try {
+        setLoading(true);
+        await actions.listingsData.getListing(listingId);
+      } catch (e) {
+        console.error('Failed to load listing details:', e);
+        Toast.error(t('listing.detail.toastLoadError'));
+        navigate('/listings');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchListing();
+  }, [listingId]);
 
-    getJourney(fromLat, fromLng, toLat, toLng).then((found) => {
-      if (request !== requestRef.current) return;
-      setJourney(found);
+  useEffect(() => {
+    setNotesDraft(listing?.notes ?? '');
+  }, [listing?.id, listing?.notes]);
+
+  // Fetched separately from the listing rather than joined onto it: most views never draw the
+  // chart, and a series has no size bound, so it must not ride along on every listing read.
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchPriceHistory() {
+      try {
+        // xhrGet resolves { status, json }, not the payload itself.
+        const { json } = await xhrGet(`/api/listings/${listingId}/priceHistory`);
+        if (!cancelled) setPriceHistory(Array.isArray(json) ? json : []);
+      } catch {
+        // A missing history is not an error worth interrupting the page for - the chart simply
+        // does not render.
+        if (!cancelled) setPriceHistory([]);
+      }
+    }
+    fetchPriceHistory();
+    return () => {
+      cancelled = true;
+    };
+  }, [listingId]);
+
+  const hasGeo =
+    listing?.latitude != null && listing?.longitude != null && listing?.latitude !== -1 && listing?.longitude !== -1;
+
+  useEffect(() => {
+    if (loading || !listing || !mapContainer.current || !hasGeo) return;
+
+    if (map.current) {
+      map.current.remove();
+    }
+
+    map.current = new maplibregl.Map({
+      container: mapContainer.current,
+      style: STYLES.STANDARD,
+      center: [listing.longitude, listing.latitude],
+      zoom: 14,
+      cooperativeGestures: true,
     });
 
+    map.current.addControl(new maplibregl.NavigationControl(), 'top-right');
+
+    new maplibregl.Marker({ color: '#3FB1CE' })
+      .setLngLat([listing.longitude, listing.latitude])
+      .setPopup(
+        new maplibregl.Popup({ offset: 25 }).setHTML(
+          `<h4>${t('listing.detail.mapPopupListingLocation')}</h4><p>${listing.address}</p>`,
+        ),
+      )
+      .addTo(map.current);
+
+    if (homeAddresses.length > 0) {
+      homeAddresses.forEach((home) => {
+        new maplibregl.Marker({ color: 'red' })
+          .setLngLat([home.coords.lng, home.coords.lat])
+          .setPopup(
+            new maplibregl.Popup({ offset: 25 }).setHTML(
+              `<h4>${home.label || t('listing.detail.mapPopupHomeAddress')}</h4><p>${home.address}</p>`,
+            ),
+          )
+          .addTo(map.current);
+      });
+
+      const bounds = getBoundsFromCoords([
+        [listing.longitude, listing.latitude],
+        ...homeAddresses.map((home) => [home.coords.lng, home.coords.lat]),
+      ]);
+
+      map.current.fitBounds(bounds, {
+        padding: 50,
+        maxZoom: 15,
+      });
+
+      const buildRouteData = () => ({
+        type: 'FeatureCollection',
+        features: homeAddresses.flatMap((home) => {
+          const distance = distanceMeters(listing.latitude, listing.longitude, home.coords.lat, home.coords.lng);
+          const midpoint = [(listing.longitude + home.coords.lng) / 2, (listing.latitude + home.coords.lat) / 2];
+          const labelPrefix = home.label ? `${home.label}: ` : '';
+          return [
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'LineString',
+                coordinates: [
+                  [listing.longitude, listing.latitude],
+                  [home.coords.lng, home.coords.lat],
+                ],
+              },
+            },
+            {
+              type: 'Feature',
+              geometry: {
+                type: 'Point',
+                coordinates: midpoint,
+              },
+              properties: {
+                distance: `${labelPrefix}${Math.round(distance)} m`,
+              },
+            },
+          ];
+        }),
+      });
+
+      const drawLine = () => {
+        if (!map.current || !map.current.isStyleLoaded()) return;
+
+        if (map.current.getSource('route')) {
+          map.current.getSource('route').setData(buildRouteData());
+        } else {
+          map.current.addSource('route', {
+            type: 'geojson',
+            data: buildRouteData(),
+          });
+
+          map.current.addLayer({
+            id: 'route',
+            type: 'line',
+            source: 'route',
+            layout: {
+              'line-join': 'round',
+              'line-cap': 'round',
+            },
+            paint: {
+              'line-color': '#3FB1CE',
+              'line-width': 4,
+              'line-dasharray': [2, 1],
+            },
+            filter: ['==', '$type', 'LineString'],
+          });
+
+          map.current.addLayer({
+            id: 'route-distance',
+            type: 'symbol',
+            source: 'route',
+            layout: {
+              'text-field': ['get', 'distance'],
+              'text-size': 14,
+              'text-offset': [0, -1],
+              'text-allow-overlap': true,
+            },
+            paint: {
+              'text-color': '#ffffff',
+              'text-halo-color': '#3FB1CE',
+              'text-halo-width': 2,
+            },
+            filter: ['==', '$type', 'Point'],
+          });
+        }
+      };
+
+      if (map.current.isStyleLoaded()) {
+        drawLine();
+      } else {
+        map.current.on('load', drawLine);
+      }
+    }
+
     return () => {
-      requestRef.current++;
+      if (map.current) {
+        map.current.remove();
+        map.current = null;
+      }
     };
-  }, [fromLat, fromLng, toLat, toLng]);
+  }, [listing, loading, homeAddresses]);
 
-  if (journey === undefined) {
+  const confirmDeletion = async (hardDelete, remember) => {
+    try {
+      if (remember) {
+        await actions.userSettings.setListingDeletionPreference({ skipPrompt: true, hardDelete });
+      }
+      await xhrDelete('/api/listings/', { ids: [listing.id], hardDelete });
+      Toast.success(t('listing.detail.toastDeleted'));
+      navigate('/listings');
+    } catch (e) {
+      Toast.error(errorMessage(e, t('listing.detail.toastDeleteError')));
+    } finally {
+      setDeleteModalVisible(false);
+    }
+  };
+
+  const handleWatch = async () => {
+    try {
+      await xhrPost('/api/listings/watch', { listingId: listing.id });
+      Toast.success(
+        listing.isWatched === 1 ? t('listing.detail.toastWatchlistRemoved') : t('listing.detail.toastWatchlistAdded'),
+      );
+      actions.listingsData.getListing(listingId);
+    } catch (e) {
+      console.error('Failed to operate Watchlist:', e);
+      Toast.error(t('listing.detail.toastWatchlistError'));
+    }
+  };
+
+  const handleStatusChange = async (next) => {
+    try {
+      await actions.listingsData.setListingStatus(listing.id, next);
+      await actions.listingsData.getListing(listingId);
+      Toast.success(next ? t('listings.toastStatusMarked', { status: next }) : t('listings.toastStatusCleared'));
+    } catch (e) {
+      console.error('Failed to update status:', e);
+      Toast.error(t('listings.toastStatusUpdateError'));
+    }
+  };
+
+  const handleSaveNotes = async () => {
+    if (!listing) return;
+    setNotesSaving(true);
+    try {
+      await actions.listingsData.setListingNotes(listing.id, notesDraft);
+      await actions.listingsData.getListing(listingId);
+      Toast.success(t('listing.detail.toastNotesSaved'));
+    } catch (e) {
+      console.error('Failed to save notes:', e);
+      Toast.error(t('listing.detail.toastNotesError'));
+    } finally {
+      setNotesSaving(false);
+    }
+  };
+
+  if (loading) {
     return (
-      <Tag color="grey" type="light">
-        {t('transit.journeyLoading')}
-      </Tag>
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+        <Spin size="large" />
+      </div>
     );
   }
 
-  if (journey == null) {
-    return (
-      <Tag color="grey" type="light">
-        {t('transit.journeyUnavailable')}
-      </Tag>
-    );
+  if (!listing) return null;
+
+  const statusKeyMap = {
+    applied: 'listing.detail.statusApplied',
+    accepted: 'listing.detail.statusAccepted',
+    rejected: 'listing.detail.statusRejected',
+  };
+  const statusLabel = listing.status?.status ? t(statusKeyMap[listing.status.status] ?? listing.status.status) : null;
+
+  const data = [
+    {
+      key: t('listing.detail.fieldPrice'),
+      value: listing.price ? (
+        <span className="listing-detail__price">{formatEuroPrice(listing.price)}</span>
+      ) : (
+        t('common.na')
+      ),
+      Icon: <IconCart />,
+      helpText: t('listing.detail.fieldPriceHelp'),
+    },
+    {
+      key: t('listing.detail.fieldSize'),
+      value: listing.size ? `${listing.size} m²` : t('common.na'),
+      Icon: <IconExpand />,
+      helpText: t('listing.detail.fieldSizeHelp'),
+    },
+    {
+      key: t('listing.detail.fieldRooms'),
+      value: listing.rooms ? t('listing.detail.fieldRoomsValue', { count: listing.rooms }) : t('common.na'),
+      Icon: <IconGridView />,
+      helpText: t('listing.detail.fieldRoomsHelp'),
+    },
+    {
+      key: t('listing.detail.fieldJob'),
+      value: listing.job_name,
+      Icon: <IconBriefcase />,
+      helpText: t('listing.detail.fieldJobHelp'),
+    },
+    {
+      key: t('listing.detail.fieldProvider'),
+      value: listing.provider ? listing.provider.charAt(0).toUpperCase() + listing.provider.slice(1) : 'Unknown',
+      Icon: <IconBriefcase />,
+      helpText: t('listing.detail.fieldProviderHelp'),
+    },
+    {
+      key: t('listing.detail.fieldAdded'),
+      value: timeService.format(listing.created_at, true, locale),
+      Icon: <IconClock />,
+      helpText: t('listing.detail.fieldAddedHelp'),
+    },
+  ];
+
+  // The verdict belongs next to the price, not only in the costing block further down. It comes
+  // with the listing from the server, decided against the same profile and thresholds the
+  // affordability filter uses, so this page can never disagree with the row the user clicked.
+  const affordabilityVerdict = listing.affordabilityVerdict ?? null;
+  const isRental = listing.dealType === 'rent';
+
+  if (affordabilityVerdict) {
+    data.push({
+      key: t('listing.detail.fieldAffordability'),
+      value: (
+        <span
+          className="listing-detail__affordability"
+          style={{
+            color: VERDICT_COLORS[affordabilityVerdict],
+            backgroundColor: withAlpha(VERDICT_COLORS[affordabilityVerdict], 0.12),
+            borderColor: withAlpha(VERDICT_COLORS[affordabilityVerdict], 0.4),
+          }}
+        >
+          {t(`finance.verdict.${affordabilityVerdict}`)}
+        </span>
+      ),
+      Icon: <IconEuro />,
+      helpText: t(
+        `listings.${isRental ? 'rentAffordabilityTooltip' : 'affordabilityTooltip'}.${affordabilityVerdict}`,
+        {
+          price: formatEuro(
+            isRental ? financeThresholds.rent.affordableMaxRent : financeThresholds.buy.affordableMaxPrice,
+            locale,
+          ),
+        },
+      ),
+    });
   }
 
-  const lines = journey.legs
-    .filter((leg) => leg.mode !== 'WALK' && leg.line)
-    .map((leg) => leg.line)
-    .join(', ');
+  if (statusLabel) {
+    data.push({
+      key: t('listing.detail.fieldStatus'),
+      value: listing.status?.setAt
+        ? `${statusLabel} ${t('listing.detail.statusSetAt', { date: timeService.format(listing.status.setAt, true, locale) })}`
+        : statusLabel,
+      Icon: <IconActivity />,
+      helpText: t('listing.detail.fieldStatusHelp'),
+    });
+  }
 
   return (
-    <Tooltip
-      content={
-        journey.transfers > 0
-          ? t('transit.journeyTransfers', { count: journey.transfers })
-          : t('transit.journeyDirect')
-      }
-    >
-      <Tag color="green" type="light">
-        {t('transit.journeyDuration', {
-          duration: formatDuration(journey.durationMinutes, {
-            minuteUnit: t('common.minuteUnit'),
-            hourUnit: t('common.hourUnit'),
-          }),
-        })}
-        {lines ? ` · ${lines}` : ''}
-      </Tag>
-    </Tooltip>
+    <div className="listing-detail">
+      <Headline
+        text={listing?.title || t('listing.detail.defaultTitle')}
+        actions={
+          <Button icon={<IconArrowLeft />} onClick={() => navigate(-1)} theme="borderless" style={{ color: '#909090' }}>
+            {t('listing.detail.back')}
+          </Button>
+        }
+      />
+
+      <Card className="listing-detail__card">
+        <div className="listing-detail__header">
+          <Space align="center">
+            <IconMapPin style={{ fontSize: '18px', color: 'var(--semi-color-primary)' }} />
+            {listing.address ? (
+              <a
+                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(listing.address)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="listing-detail__address-link"
+              >
+                {listing.address}
+              </a>
+            ) : (
+              <Text type="secondary">{t('listing.detail.noAddress')}</Text>
+            )}
+          </Space>
+          <Space wrap className="listing-detail__header-actions">
+            <Button
+              icon={listing.isWatched === 1 ? <IconStar /> : <IconStarStroked />}
+              onClick={handleWatch}
+              theme="borderless"
+              className={`listing-detail__watch-btn${listing.isWatched === 1 ? ' listing-detail__watch-btn--active' : ''}`}
+            >
+              {listing.isWatched === 1 ? t('listing.detail.watched') : t('listing.detail.watch')}
+            </Button>
+            <StatusControl status={listing.status?.status ?? null} onChange={handleStatusChange} />
+            <a href={listing.link} target="_blank" rel="noopener noreferrer" className="listing-detail__open-btn">
+              <IconLink style={{ marginRight: 6 }} />
+              {t('listing.detail.openListing')}
+            </a>
+            <Button
+              icon={<IconDelete />}
+              onClick={() => {
+                if (listingDeletionPref?.skipPrompt) {
+                  confirmDeletion(listingDeletionPref.hardDelete);
+                  return;
+                }
+                setDeleteModalVisible(true);
+              }}
+              theme="light"
+              type="danger"
+            >
+              {t('listing.detail.delete')}
+            </Button>
+          </Space>
+        </div>
+
+        <Row>
+          <Col span={24} lg={12}>
+            <div
+              className={`listing-detail__image-container${!listing.image_url ? ' listing-detail__image-container--placeholder' : ''}`}
+            >
+              <Image
+                src={listing.image_url ?? no_image}
+                fallback={<img src={no_image} alt={t('listing.detail.noImageAlt')} />}
+                style={{ width: '100%', height: '100%' }}
+                preview={!!listing.image_url}
+              />
+            </div>
+
+            <div className="listing-detail__notes">
+              <Title heading={4} className="listing-detail__notes-title">
+                {t('listing.detail.notesTitle')}
+              </Title>
+              <TextArea
+                value={notesDraft}
+                onChange={(val) => setNotesDraft(val)}
+                placeholder={t('listing.detail.notesPlaceholder')}
+                rows={5}
+                autosize={{ minRows: 4, maxRows: 12 }}
+                className="listing-detail__notes-textarea"
+                showClear
+              />
+              <Space className="listing-detail__notes-actions">
+                <Button
+                  theme="solid"
+                  type="primary"
+                  loading={notesSaving}
+                  disabled={notesSaving || (notesDraft ?? '') === (listing.notes ?? '')}
+                  onClick={handleSaveNotes}
+                >
+                  {t('listing.detail.storeNotes')}
+                </Button>
+              </Space>
+            </div>
+
+            {/* The map used to run the full width under the card, which pushed it a screen
+                below the figures. In this column it sits beside the details and the costing,
+                so the whole listing fits on one screen. */}
+            <div className="listing-detail__map-wrapper">
+              <Title heading={4} className="listing-detail__map-title">
+                {t('listing.detail.locationTitle')}
+              </Title>
+              {!hasGeo ? (
+                <Banner type="warning" bordered description={t('listing.detail.noGeoWarning')} />
+              ) : (
+                <div ref={mapContainer} className="listing-detail__map-container" />
+              )}
+            </div>
+
+            {/* "How do I get out of here?" belongs right next to the map, and only makes sense
+                once the listing has coordinates to look up. */}
+            {hasGeo && (
+              <div className="listing-detail__transit">
+                <Title heading={4} className="listing-detail__map-title">
+                  {t('transit.nearbyTitle')}
+                </Title>
+                <NearbyStops lat={listing.latitude} lng={listing.longitude} limit={3} expandFirst />
+              </div>
+            )}
+          </Col>
+          <Col span={24} lg={12}>
+            <div className="listing-detail__info-section">
+              <Title heading={4} style={{ marginBottom: '1rem' }}>
+                {t('listing.detail.detailsTitle')}
+              </Title>
+              <Descriptions column={1}>
+                {data.map((item, index) => (
+                  <Descriptions.Item key={index}>
+                    <Tooltip content={item.helpText} position="left">
+                      <span className="listing-detail__details-item">
+                        {item.Icon}
+                        {item.value}
+                      </span>
+                    </Tooltip>
+                  </Descriptions.Item>
+                ))}
+              </Descriptions>
+
+              {/* Directly under the figures it explains. The chart hides itself below two
+                  readings, so a listing whose price has never moved shows nothing at all rather
+                  than an empty frame. */}
+              {priceHistory.length >= 2 && (
+                <>
+                  <Divider margin="1.5rem" />
+                  <Title heading={6} style={{ marginBottom: '0.75rem' }}>
+                    {t('listing.detail.priceHistory')}
+                  </Title>
+                  <PriceHistoryChart data={priceHistory} locale={locale} />
+                </>
+              )}
+
+              {/* The costing answers "can I have this?", which is the question asked right
+                  after the price - so it comes before the sales copy, not after it. */}
+              <ListingFinanceCard listing={listing} />
+
+              {/* Without the matching half of the profile there is nothing to compute, so offer
+                  the way to create it instead of hiding the feature completely. */}
+              {!(isRental ? rentComplete : buyComplete) && listing.price != null && (
+                <>
+                  <Divider margin="1.5rem" />
+                  <Space align="center" wrap>
+                    <IconEuro style={{ fontSize: '18px', color: 'var(--semi-color-primary)' }} />
+                    <Text type="secondary">
+                      {t(isRental ? 'listing.detail.rentSetupHint' : 'listing.detail.financeSetupHint')}
+                    </Text>
+                    <Button
+                      theme="borderless"
+                      size="small"
+                      onClick={() =>
+                        navigate(
+                          isRental
+                            ? '/finance'
+                            : `/finance?dealType=buy&price=${listing.price}&listingId=${listing.id}`,
+                        )
+                      }
+                    >
+                      {t(isRental ? 'listing.detail.rentSetup' : 'listing.detail.financeCalculate')}
+                    </Button>
+                  </Space>
+                </>
+              )}
+
+              <Divider margin="1.5rem" />
+              <Title heading={4} style={{ marginBottom: '1rem' }}>
+                {t('listing.detail.descriptionTitle')}
+              </Title>
+              <Text type="secondary" style={{ whiteSpace: 'pre-wrap' }}>
+                {listing.description || t('listing.detail.noDescription')}
+              </Text>
+
+              {Array.isArray(listing.distances) && listing.distances.length > 0 && (
+                <>
+                  <Divider margin="1.5rem" />
+                  <Space align="center" wrap>
+                    <IconActivity style={{ fontSize: '18px', color: 'var(--semi-color-primary)' }} />
+                    <Text strong>{t('listing.detail.distanceToHome')}</Text>
+                    {listing.distances.map((d) => {
+                      const home = homeAddresses.find((address) => address.label === d.label);
+                      return (
+                        <Space key={d.label} spacing={4}>
+                          <Tag color="blue">
+                            {d.label}: {d.meters} m
+                          </Tag>
+                          {home?.coords && (
+                            <JourneyBadge
+                              fromLat={listing.latitude}
+                              fromLng={listing.longitude}
+                              toLat={home.coords.lat}
+                              toLng={home.coords.lng}
+                            />
+                          )}
+                        </Space>
+                      );
+                    })}
+                  </Space>
+                </>
+              )}
+            </div>
+          </Col>
+        </Row>
+      </Card>
+
+      <ListingDeletionModal
+        visible={deleteModalVisible}
+        defaultDeleteType={defaultDeleteType}
+        onConfirm={confirmDeletion}
+        onCancel={() => setDeleteModalVisible(false)}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
Add public transit travel time to listing detail page

Shows a badge next to each saved home/work address on a listing's
detail page with the estimated public transit travel time between
that address and the listing, using the Transitous API that is
already used elsewhere in the app for nearby stops and departures.

Calculation is on-demand only, triggered when a listing detail page
is opened - never batched across a list - and cached for an hour,
since Transitous names journey planning as a heavier endpoint than
simple stop/departure lookups.