### PR TITLE
fix(immoscout): prevent base64 corruption of raw map shape polylines

### DIFF
--- a/lib/services/immoscout/immoscout-web-translator.js
+++ b/lib/services/immoscout/immoscout-web-translator.js
@@ -256,9 +256,7 @@ export function convertWebToMobile(webUrl) {
 
   if (isShape && webParams.shape) {
     const browserShape = Array.isArray(webParams.shape) ? webParams.shape[0] : webParams.shape;
-    const normalized = browserShape.replace(/\.\./g, '==').replace(/\./g, '=');
-    const polyline = Buffer.from(normalized, 'base64').toString('utf-8');
-    mobileParams.shape = polyline;
+    mobileParams.shape = browserShape.split(';')[0];
   }
 
   if (webParams.geocoordinates) {


### PR DESCRIPTION
ImmoScout web search URLs with custom map shapes pass raw Google Encoded Polylines. Base64-decoding them corrupts the polyline bytes into invalid UTF-8 characters (%EF%BF%BD), causing ImmoScout's mobile API to reject requests with HTTP 400 Bad Request: Cannot parse shape / 500 Internal Server Error.

This change passes the raw shape string directly without base64 decoding.