### PR TITLE
Add anlageimmobilie REAL_ESTATE_TYPE for immoscout

### DIFF
--- a/lib/services/immoscout/immoscout-web-translator.js
+++ b/lib/services/immoscout/immoscout-web-translator.js
@@ -116,7 +116,7 @@ const REAL_ESTATE_TYPE = {
   'luxushaus-kaufen': 'housebuy',
   'villa-kaufen': 'housebuy',
   'neubauhaus-kaufen': 'housebuy',
-  'anlageimmobilie': 'investment',
+  anlageimmobilie: 'investment',
 };
 
 const WEB_PATH_TO_APARTMENT_EQUIPMENT_MAP = {

--- a/lib/services/immoscout/immoscout-web-translator.js
+++ b/lib/services/immoscout/immoscout-web-translator.js
@@ -116,6 +116,7 @@ const REAL_ESTATE_TYPE = {
   'luxushaus-kaufen': 'housebuy',
   'villa-kaufen': 'housebuy',
   'neubauhaus-kaufen': 'housebuy',
+  'anlageimmobilie': 'investment',
 };
 
 const WEB_PATH_TO_APARTMENT_EQUIPMENT_MAP = {

--- a/test/services/immoscout/immoscout-web-translator.test.js
+++ b/test/services/immoscout/immoscout-web-translator.test.js
@@ -185,6 +185,17 @@ describe('#immoscout-mobile URL conversion', () => {
     expect(queryParams.get('newbuilding')).toBe('true');
   });
 
+  // "Anlageimmobilien" is its own real estate type on the mobile API and its web
+  // path carries neither a "-kaufen" nor a "-mieten" suffix.
+  it('should convert anlageimmobilie to the investment real estate type', () => {
+    const webUrl = 'https://www.immobilienscout24.de/Suche/de/berlin/berlin/anlageimmobilie';
+
+    const converted = convertWebToMobile(webUrl);
+    const queryParams = new URL(converted).searchParams;
+    expect(queryParams.get('realestatetype')).toBe('investment');
+    expect(queryParams.get('geocodes')).toBe('/de/berlin/berlin');
+  });
+
   // Sanity check: the corresponding "-mieten" slugs must remain untouched
   // by the suffix-based realType resolution introduced above.
   it.each([


### PR DESCRIPTION
# Summary

Adds `anlageimmobilie` to the `REAL_ESTATE_TYPE` map in the ImmoScout web→mobile URL
translator, mapping it to the mobile API's `investment` real estate type. Search URLs like `https://www.immobilienscout24.de/Suche/de/berlin/berlin/anlageimmobilie`
previously threw `Real estate type not found: anlageimmobilie`.

# Changes

- `lib/services/immoscout/immoscout-web-translator.js` → new `anlageimmobilie: 'investment'` mapping
- `test/services/immoscout/immoscout-web-translator.test.js` → test asserting the slug resolves to
  `realestatetype=investment` and keeps its geocodes

# Validation

- `yarn test:offline`

All tests pass.
