### PR TITLE
feat: opt into ImmoScout tenant-network pool via &tenantNetwork=true

### DIFF
--- a/lib/services/immoscout/immoscout-web-translator.js
+++ b/lib/services/immoscout/immoscout-web-translator.js
@@ -89,6 +89,7 @@ const PARAM_NAME_MAP = {
   sorting: 'sorting',
   newbuilding: 'newbuilding',
   fulltext: 'fulltext',
+  tenantNetwork: 'tenantNetwork',
 };
 
 const EQUIPMENT_MAP = {

--- a/test/services/immoscout/immoscout-web-translator.test.js
+++ b/test/services/immoscout/immoscout-web-translator.test.js
@@ -199,6 +199,16 @@ describe('#immoscout-mobile URL conversion', () => {
     expect(queryParams.get('apartmenttypes')).toBe(apartmentType);
   });
 
+  // The tenantNetwork flag opts into the mobile API's "Mieter-Netzwerk" pool.
+  it('should forward the tenantNetwork flag when present in the web URL', () => {
+    const webUrl =
+      'https://www.immobilienscout24.de/Suche/de/nordrhein-westfalen/neuss-rhein-kreis/rommerskirchen/wohnung-mieten?enteredFrom=result_list&tenantNetwork=true';
+
+    const converted = convertWebToMobile(webUrl);
+    const queryParams = new URL(converted).searchParams;
+    expect(queryParams.get('tenantNetwork')).toBe('true');
+  });
+
   // Test URL conversion with unsupported query parameters
   it('should remove unsupported query parameters', () => {
     const webUrl = 'https://www.immobilienscout24.de/Suche/de/berlin/berlin/wohnung-mieten?minimuminternetspeed=100000';


### PR DESCRIPTION
## Summary

Adds `tenantNetwork` to the forwarded params whitelist in the ImmoScout web→mobile URL
translator. ImmoScout has a second listing pool ("Mieter-Netzwerk"), flats where you contact
the **current tenant** instead of a landlord, which the mobile API hides from the default
`/search/list`. Search URLs with `&tenantNetwork=true` appended now resolve to that pool, so
the same `immoscout` provider can be added to a job twice (once plain, once with the flag) to
cover both pools. No change for existing jobs; the flag is absent unless the user adds it, so
behaviour is identical to today.

## Changes

* `lib/services/immoscout/immoscout-web-translator.js` → new `tenantNetwork: 'tenantNetwork'`
entry in `PARAM_NAME_MAP`, forwarded verbatim to the mobile API when present in the web URL
* `test/services/immoscout/immoscout-web-translator.test.js` → test asserting `&tenantNetwork=true`
is forwarded; the existing exact URL conversion test already guards that it isn't emitted for
normal URLs

## Validation

* `yarn test:offline`: 128 files, 1223 tests passed
* `yarn lint`: clean
* `yarn format:check`: clean

All tests pass.