### PR TITLE
perf(storage): optimize user-scoped listing queries

### DIFF
--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -22,6 +22,46 @@ import { DEAL_TYPES } from '../dealType.js';
 const ID_CHUNK_SIZE = 500;
 
 /**
+ * SQL predicate granting access to a job owned by or shared with the current user.
+ *
+ * Keeping the rule separate from the query shape lets broad listing queries resolve the accessible
+ * job set once, while point queries inspect only the job belonging to the one selected listing.
+ *
+ * @param {string} alias - Trusted SQL alias supplied by this module.
+ * @returns {string}
+ */
+const jobAccessSql = (alias) => `(${alias}.user_id = @userId OR EXISTS (
+  SELECT 1
+  FROM json_each(${alias}.shared_with_user) AS scoped_user
+  WHERE scoped_user.value = @userId
+))`;
+
+/**
+ * Scope broad listing queries through the small jobs table before touching listings.
+ *
+ * Expressing this as a predicate on the joined job made SQLite scan the entire listings table and
+ * run `json_each` once per listing. The subquery is evaluated per job instead, after which SQLite
+ * can seek listings through the existing `(job_id, hash)` index.
+ * @type {string}
+ */
+const USER_LISTING_SET_SCOPE_SQL = `l.job_id IN (
+  SELECT scoped_job.id
+  FROM jobs scoped_job
+  WHERE ${jobAccessSql('scoped_job')}
+)`;
+
+/**
+ * Scope a point lookup through only the job belonging to its selected listing.
+ * @type {string}
+ */
+const USER_LISTING_POINT_SCOPE_SQL = `EXISTS (
+  SELECT 1
+  FROM jobs scoped_job
+  WHERE scoped_job.id = l.job_id
+    AND ${jobAccessSql('scoped_job')}
+)`;
+
+/**
  * Run `fn` over `ids` in {@link ID_CHUNK_SIZE}-sized slices inside one transaction.
  *
  * The transaction makes the chunking invisible to readers: either every id is processed or none is,
@@ -755,9 +795,7 @@ export const queryListings = ({
   // user scoping (non-admin only): restrict to listings whose job belongs to user
   if (!isAdmin) {
     // Include listings from jobs owned by the user or jobs shared with the user
-    whereParts.push(
-      `(j.user_id = @userId OR EXISTS (SELECT 1 FROM json_each(j.shared_with_user) AS sw WHERE sw.value = @userId))`,
-    );
+    whereParts.push(USER_LISTING_SET_SCOPE_SQL);
   }
   if (freeTextFilter && String(freeTextFilter).trim().length > 0) {
     params.filter = `%${String(freeTextFilter).trim()}%`;
@@ -1131,9 +1169,7 @@ export const getListingsForMap = ({ jobId, userId = null, isAdmin = false } = {}
   const params = { userId: userId || '__NO_USER__' };
 
   if (!isAdmin) {
-    baseWhereParts.push(
-      `(j.user_id = @userId OR EXISTS (SELECT 1 FROM json_each(j.shared_with_user) AS sw WHERE sw.value = @userId))`,
-    );
+    baseWhereParts.push(USER_LISTING_SET_SCOPE_SQL);
   }
 
   if (jobId) {
@@ -1645,7 +1681,7 @@ export const getListingById = (id, userId = null, isAdmin = false) => {
   const params = { id, userId: userId || '__NO_USER__' };
   let whereScoping = '';
   if (!isAdmin) {
-    whereScoping = `AND (j.user_id = @userId OR EXISTS (SELECT 1 FROM json_each(j.shared_with_user) AS sw WHERE sw.value = @userId))`;
+    whereScoping = `AND ${USER_LISTING_POINT_SCOPE_SQL}`;
   }
   const row = parseListingStatus(
     SqliteConnection.query(

--- a/test/storage/listingStatus.test.js
+++ b/test/storage/listingStatus.test.js
@@ -210,6 +210,20 @@ describe('listingsStorage.getListingById', () => {
     const row = listingsStorage.getListingById('missing', 'u1', true);
     expect(row).toBeNull();
   });
+
+  it('checks only the selected listing job for a non-admin user', () => {
+    sqliteMock.__queryHandler = () => [];
+
+    listingsStorage.getListingById('a', 'u1', false);
+
+    const { sql, params } = calls.query[0];
+    expect(sql).toContain('EXISTS');
+    expect(sql).toContain('scoped_job.id = l.job_id');
+    expect(sql).toContain('scoped_job.user_id = @userId');
+    expect(sql).toContain('json_each(scoped_job.shared_with_user)');
+    expect(sql).not.toContain('l.job_id IN');
+    expect(params).toMatchObject({ id: 'a', userId: 'u1' });
+  });
 });
 
 describe('watchListStorage.ensureWatch', () => {

--- a/test/storage/queryListingsAffordability.test.js
+++ b/test/storage/queryListingsAffordability.test.js
@@ -134,7 +134,9 @@ describe('queryListings affordabilityBand', () => {
   it('keeps the user scoping clause in place', () => {
     listingsStorage.queryListings({ userId: 'u1', affordabilityBand: buyOnly(30000, 412000) });
 
-    expect(pageQuery().sql).toContain('j.user_id = @userId');
+    expect(pageQuery().sql).toContain('l.job_id IN');
+    expect(pageQuery().sql).toContain('scoped_job.user_id = @userId');
+    expect(pageQuery().sql).toContain('json_each(scoped_job.shared_with_user)');
   });
 
   it('ignores non-numeric bounds rather than emitting a broken clause', () => {

--- a/test/storage/queryListingsAffordabilitySql.test.js
+++ b/test/storage/queryListingsAffordabilitySql.test.js
@@ -207,4 +207,31 @@ describe('queryListings affordability band against real SQLite', () => {
     expect(byId['buy-cheap']).toBe('buy');
     expect(byId['rent-cheap']).toBe('rent');
   });
+
+  it('lets a shared user open a listing but rejects a foreign listing', () => {
+    db.prepare(`INSERT INTO jobs (id, user_id, name, shared_with_user, deal_type) VALUES (?, ?, ?, ?, 'rent')`).run(
+      'job-shared',
+      'owner-2',
+      'Shared job',
+      JSON.stringify([USER]),
+    );
+    db.prepare(`INSERT INTO jobs (id, user_id, name, shared_with_user, deal_type) VALUES (?, ?, ?, '[]', 'rent')`).run(
+      'job-foreign',
+      'owner-3',
+      'Foreign job',
+    );
+    db.prepare(`INSERT INTO listings (id, job_id, price, title) VALUES (?, ?, 900, ?)`).run(
+      'shared-listing',
+      'job-shared',
+      'Shared listing',
+    );
+    db.prepare(`INSERT INTO listings (id, job_id, price, title) VALUES (?, ?, 900, ?)`).run(
+      'foreign-listing',
+      'job-foreign',
+      'Foreign listing',
+    );
+
+    expect(listingsStorage.getListingById('shared-listing', USER)?.id).toBe('shared-listing');
+    expect(listingsStorage.getListingById('foreign-listing', USER)).toBeNull();
+  });
 });


### PR DESCRIPTION
Resolve accessible job IDs before broad listing reads so SQLite can use the existing (job_id, hash) index instead of scanning every listing and evaluating json_each for each row.

Use a job-correlated access check for single-listing lookups, preserving primary-key performance while keeping owner access, shared-job access, and the administrator bypass unchanged.