### PR TITLE
fix(filters): preserve non-default null filter state in useUrlState to fix the "All" filter

### DIFF
--- a/test/ui/listingFilters.test.js
+++ b/test/ui/listingFilters.test.js
@@ -39,7 +39,9 @@ describe('listingFilters', () => {
     });
 
     it('counts nothing once everything is cleared', () => {
-      expect(countActiveFilters({ ...defaults(), ...clearAllFilters() })).toBe(0);
+      const cleared = clearAllFilters();
+      expect(cleared.active).toBe(null);
+      expect(countActiveFilters({ ...defaults(), ...cleared })).toBe(0);
     });
 
     it('counts each filter once', () => {

--- a/test/ui/useUrlState.test.js
+++ b/test/ui/useUrlState.test.js
@@ -92,6 +92,12 @@ describe('useUrlState', () => {
       expect(state.params.has('q')).toBe(false);
     });
 
+    it('drops a number param set to null instead of writing "null"', () => {
+      const { pair, state } = makeSearchParams('page=3');
+      useUrlState(pair(), SCHEMA).setValue('page', null);
+      expect(state.params.has('page')).toBe(false);
+    });
+
     it('ignores keys the schema does not declare', () => {
       const { pair, state } = makeSearchParams();
       useUrlState(pair(), SCHEMA).setValues({ nonsense: 'x' });

--- a/test/ui/useUrlState.test.js
+++ b/test/ui/useUrlState.test.js
@@ -56,6 +56,11 @@ describe('useUrlState', () => {
       expect(values).toEqual({ page: 3, q: 'altbau', active: false, hidden: true });
     });
 
+    it('decodes active=all as null when schema default is true', () => {
+      const { pair } = makeSearchParams('active=all');
+      expect(useUrlState(pair(), SCHEMA).values.active).toBe(null);
+    });
+
     it('tells a nullable boolean apart from its default', () => {
       const { pair } = makeSearchParams('active=false');
       expect(useUrlState(pair(), SCHEMA).values.active).toBe(false);
@@ -73,6 +78,12 @@ describe('useUrlState', () => {
       const { pair, state } = makeSearchParams('page=4');
       useUrlState(pair(), SCHEMA).setValue('page', 1);
       expect(state.params.has('page')).toBe(false);
+    });
+
+    it('stores active=all in URL when set to null if defaultValue is non-null', () => {
+      const { pair, state } = makeSearchParams();
+      useUrlState(pair(), SCHEMA).setValue('active', null);
+      expect(state.params.get('active')).toBe('all');
     });
 
     it('drops a param set to null', () => {

--- a/ui/src/hooks/useSearchParamState.js
+++ b/ui/src/hooks/useSearchParamState.js
@@ -13,12 +13,12 @@ export const parseString = {
 
 export const parseNumber = {
   parse: (v) => Number(v),
-  stringify: (v) => String(v),
+  stringify: (v) => (v == null ? null : String(v)),
 };
 
 export const parseBoolean = {
   parse: (v) => v === 'true',
-  stringify: (v) => String(v),
+  stringify: (v) => (v == null ? null : String(v)),
 };
 
 // For state that is null | true | false

--- a/ui/src/hooks/useSearchParamState.js
+++ b/ui/src/hooks/useSearchParamState.js
@@ -24,7 +24,7 @@ export const parseBoolean = {
 // For state that is null | true | false
 export const parseNullableBoolean = {
   parse: (v) => (v === 'true' ? true : v === 'false' ? false : null),
-  stringify: (v) => (v === null ? null : String(v)),
+  stringify: (v) => (v === null ? "all" : String(v)),
 };
 
 /**
@@ -74,9 +74,9 @@ export function useUrlState([searchParams, setSearchParams], schema) {
             const entry = schema[key];
             if (entry == null) continue;
             const { defaultValue, codec = parseString } = entry;
-            const asString = value == null ? null : codec.stringify(value);
+            const asString = codec.stringify(value);
             // The default never appears in the URL: its absence is what the default means.
-            if (value === defaultValue || value == null || asString == null) {
+            if (value === defaultValue || asString == null) {
               next.delete(key);
             } else {
               next.set(key, asString);

--- a/ui/src/hooks/useSearchParamState.js
+++ b/ui/src/hooks/useSearchParamState.js
@@ -24,7 +24,7 @@ export const parseBoolean = {
 // For state that is null | true | false
 export const parseNullableBoolean = {
   parse: (v) => (v === 'true' ? true : v === 'false' ? false : null),
-  stringify: (v) => (v === null ? "all" : String(v)),
+  stringify: (v) => (v === null ? 'all' : String(v)),
 };
 
 /**


### PR DESCRIPTION
## Summary
Nice new filter update! I noticed the "All" activity button does not work (actually already before, just forgot to report it). 
This PR fixes the issue where clicking the "All" activity filter (`active: null`) failed to stay active and immediately reset to `active: true` on re-render.

## Root Cause
`useUrlState` unconditionally deleted `null` values from search parameters. For filters like `active` whose `defaultValue` is `true`, removing the key from the URL caused `useUrlState` to fall back to `true`, preventing `active: null` from being retained.

## Fix
- Encode `null` as `"all"` in `parseNullableBoolean.stringify`.
- Preserve non-default `null` parameter state in `useUrlState.setValues` so `active=all` persists in the URL.
- Added unit tests for `active=all` URL serialization and reading.