### PR TITLE
Fix Immowelt encoded search filters

### DIFF
--- a/lib/services/immowelt/immowelt-search-model.js
+++ b/lib/services/immowelt/immowelt-search-model.js
@@ -25,8 +25,6 @@
  * @see lib/services/immowelt/immoweltBff.js for the transport that sends this.
  */
 
-import logger from '../logger.js';
-
 /** Base url of the search page these query strings come from. */
 export const IMMOWELT_SEARCH_PATH = '/classified-search';
 
@@ -43,7 +41,15 @@ export const DEFAULT_ORDER = 'DateDesc';
 const LIST_PARAMS = ['distributionTypes', 'estateTypes', 'estateSubTypes', 'projectTypes', 'featuresIncluded'];
 
 /** Query parameters holding a single number, copied to `criteria` as numbers under the same name. */
-const NUMBER_PARAMS = ['priceMin', 'priceMax', 'numberOfRoomsMin', 'numberOfRoomsMax', 'spaceMin', 'spaceMax'];
+const NUMBER_PARAMS = [
+  'priceMin',
+  'priceMax',
+  'numberOfRoomsMin',
+  'numberOfRoomsMax',
+  'spaceMin',
+  'spaceMax',
+  'yearOfConstructionMin',
+];
 
 /**
  * Query parameters holding a single enum value. The url spells these in whatever case the UI
@@ -87,6 +93,64 @@ function toList(value) {
 }
 
 /**
+ * Whether a location value has the base64url prefix produced by JSON objects beginning with `{`.
+ * Raw immowelt place ids use a different uppercase identifier format.
+ *
+ * @param {string} value one entry from the `locations` query parameter
+ * @returns {boolean}
+ */
+function looksLikeEncodedLocation(value) {
+  return /^eyJ[A-Za-z0-9_-]*$/.test(value);
+}
+
+/**
+ * Translate either legacy raw place ids or immowelt's current encoded location object.
+ *
+ * The current search UI stores a base64url-encoded JSON object containing both a `placeId` and the
+ * polyline of the selected radius. Its BFF request uses that boundary as
+ * `location.polylines: [polyline]`; sending only the place id would silently widen the search to
+ * the whole place. Encoded objects without a polyline retain their place-id semantics.
+ *
+ * @param {string|null} raw the `locations` query parameter
+ * @returns {{placeIds: string[]} | {polylines: string[]}}
+ * @throws {Error} when the location is missing or its encoded form cannot be translated exactly
+ */
+function translateLocation(raw) {
+  const entries = toList(raw ?? '');
+  if (entries.length === 0) {
+    throw new Error("Immowelt search url carries no 'locations' parameter, so there is nothing to search in.");
+  }
+
+  const encodedEntries = entries.filter(looksLikeEncodedLocation);
+  if (encodedEntries.length === 0) return { placeIds: entries };
+  if (entries.length !== 1) {
+    throw new Error('Immowelt encoded locations cannot be combined with additional location entries.');
+  }
+
+  let decoded;
+  try {
+    decoded = JSON.parse(Buffer.from(entries[0], 'base64url').toString('utf8'));
+  } catch {
+    throw new Error('Immowelt search url carries a malformed encoded location.');
+  }
+
+  if (decoded == null || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    throw new Error('Immowelt encoded location must be a JSON object.');
+  }
+  if (typeof decoded.placeId !== 'string' || decoded.placeId.trim() === '') {
+    throw new Error("Immowelt encoded location carries no valid 'placeId'.");
+  }
+  if (decoded.polyline != null) {
+    if (typeof decoded.polyline !== 'string' || decoded.polyline.trim() === '') {
+      throw new Error("Immowelt encoded location carries an invalid 'polyline'.");
+    }
+    return { polylines: [decoded.polyline] };
+  }
+
+  return { placeIds: [decoded.placeId] };
+}
+
+/**
  * Build the BFF request for one immowelt search url.
  *
  * @param {string} searchUrl the job's search url, after `queryStringMutator` has forced the sort order
@@ -112,11 +176,10 @@ export function convertSearchUrlToRequest(searchUrl, { size = DEFAULT_PAGE_SIZE 
     const raw = params.get(name);
     if (raw == null || raw.trim() === '') continue;
     const value = Number(raw);
-    // A typo in a price would otherwise reach the BFF as NaN, which serialises to null and is
-    // silently treated as "no limit" - the user would get listings way outside their budget.
+    // NaN serialises to null, which the BFF silently treats as "no limit". Refuse the job instead
+    // of widening a constraint the user explicitly configured.
     if (!Number.isFinite(value)) {
-      logger.warn(`Ignoring immowelt search parameter '${name}': '${raw}' is not a number.`);
-      continue;
+      throw new Error(`Immowelt search parameter '${name}' must be a finite number; received '${raw}'.`);
     }
     criteria[name] = value;
   }
@@ -127,13 +190,7 @@ export function convertSearchUrlToRequest(searchUrl, { size = DEFAULT_PAGE_SIZE 
     criteria[name] = toPascalCase(raw.trim());
   }
 
-  const placeIds = toList(params.get('locations') ?? '');
-  if (placeIds.length === 0) {
-    throw new Error(
-      `Immowelt search url carries no 'locations' parameter, so there is nothing to search in: ${searchUrl}`,
-    );
-  }
-  criteria.location = { placeIds };
+  criteria.location = translateLocation(params.get('locations'));
 
   const page = Number(params.get('page') ?? 1);
   const paging = {
@@ -142,13 +199,13 @@ export function convertSearchUrlToRequest(searchUrl, { size = DEFAULT_PAGE_SIZE 
     order: params.get('order') || DEFAULT_ORDER,
   };
 
-  warnAboutUnhandledParams(params, searchUrl);
+  assertNoUnhandledParams(params);
 
   return { criteria, paging };
 }
 
 /**
- * Log every query parameter this translator does not understand.
+ * Refuse every query parameter this translator does not understand.
  *
  * An unknown parameter is always a narrowing filter the user set in immowelt's UI (a radius, a
  * drawn polygon, a construction year). Dropping it silently would hand the user a search wider
@@ -156,10 +213,9 @@ export function convertSearchUrlToRequest(searchUrl, { size = DEFAULT_PAGE_SIZE 
  * they excluded on purpose.
  *
  * @param {URLSearchParams} params the url's query parameters
- * @param {string} searchUrl the url, for the log line
  * @returns {void}
  */
-function warnAboutUnhandledParams(params, searchUrl) {
+function assertNoUnhandledParams(params) {
   const handled = new Set([...LIST_PARAMS, ...NUMBER_PARAMS, ...ENUM_PARAMS, ...PAGING_PARAMS, 'locations']);
 
   const unhandled = [...new Set(params.keys())].filter(
@@ -167,9 +223,9 @@ function warnAboutUnhandledParams(params, searchUrl) {
   );
 
   if (unhandled.length > 0) {
-    logger.warn(
-      `Immowelt search url uses filter(s) Fredy cannot translate yet: ${unhandled.join(', ')}. ` +
-        `Those are ignored, so the search runs wider than the one in your browser. Url: ${searchUrl}`,
+    throw new Error(
+      `Immowelt search url uses filter(s) Fredy cannot translate exactly: ${unhandled.join(', ')}. ` +
+        'The search was stopped to avoid returning broader results.',
     );
   }
 }

--- a/test/services/immowelt/immowelt-search-model.test.js
+++ b/test/services/immowelt/immowelt-search-model.test.js
@@ -3,15 +3,15 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   convertSearchUrlToRequest,
   DEFAULT_ORDER,
   DEFAULT_PAGE_SIZE,
 } from '../../../lib/services/immowelt/immowelt-search-model.js';
-import logger from '../../../lib/services/logger.js';
-
 const BASE = 'https://www.immowelt.de/classified-search';
+
+const encodeLocation = (location) => Buffer.from(JSON.stringify(location)).toString('base64url');
 
 describe('#immowelt search model', () => {
   it('translates the minimal search a job url carries', () => {
@@ -58,15 +58,41 @@ describe('#immowelt search model', () => {
     });
   });
 
+  it('translates the current encoded radius location and construction year exactly', () => {
+    const locations = encodeLocation({
+      placeId: 'STRTDE123456',
+      radius: 2,
+      polyline: 'encoded-search-boundary',
+      coordinates: { lat: 1, lng: 2 },
+    });
+    const { criteria } = convertSearchUrlToRequest(
+      `${BASE}?distributionTypes=Buy&estateTypes=Apartment&locations=${locations}` +
+        `&spaceMin=80&spaceMax=105&yearOfConstructionMin=2010`,
+    );
+
+    expect(criteria).toEqual({
+      distributionTypes: ['Buy'],
+      estateTypes: ['Apartment'],
+      spaceMin: 80,
+      spaceMax: 105,
+      yearOfConstructionMin: 2010,
+      location: { polylines: ['encoded-search-boundary'] },
+    });
+  });
+
+  it('uses the place id when an encoded location has no radius polyline', () => {
+    const locations = encodeLocation({ placeId: 'STRTDE123456' });
+    const { criteria } = convertSearchUrlToRequest(`${BASE}?distributionTypes=Buy&locations=${locations}`);
+
+    expect(criteria.location).toEqual({ placeIds: ['STRTDE123456'] });
+  });
+
   // NaN serialises to null, which the BFF reads as "no limit" - the user would silently get
   // listings far outside the budget they typed.
-  it('drops a range filter that is not a number instead of sending NaN', () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    const { criteria } = convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=AD08DE8634&priceMax=abc`);
-
-    expect(criteria).not.toHaveProperty('priceMax');
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('priceMax'));
-    warn.mockRestore();
+  it('refuses a range filter that is not a number instead of widening the search', () => {
+    expect(() => convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=AD08DE8634&priceMax=abc`)).toThrow(
+      /priceMax.*finite number/,
+    );
   });
 
   it('normalises the single-value enums to the PascalCase the BFF insists on', () => {
@@ -100,23 +126,39 @@ describe('#immowelt search model', () => {
     );
   });
 
+  it('refuses malformed encoded locations', () => {
+    expect(() => convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=eyJbroken`)).toThrow(
+      /malformed encoded location/,
+    );
+  });
+
+  it('refuses an encoded location without a place id', () => {
+    const locations = encodeLocation({ polyline: 'encoded-search-boundary' });
+    expect(() => convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=${locations}`)).toThrow(
+      /no valid 'placeId'/,
+    );
+  });
+
+  it('refuses an invalid encoded polyline', () => {
+    const locations = encodeLocation({ placeId: 'STRTDE123456', polyline: '' });
+    expect(() => convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=${locations}`)).toThrow(
+      /invalid 'polyline'/,
+    );
+  });
+
   // A filter that is dropped without a word turns into notifications for exactly the flats the
   // user excluded on purpose.
-  it('warns about a filter it cannot translate', () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=AD08DE8634&constructionYearMin=1990`);
-
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('constructionYearMin'));
-    warn.mockRestore();
+  it('refuses a filter it cannot translate instead of widening the search', () => {
+    expect(() =>
+      convertSearchUrlToRequest(`${BASE}?distributionTypes=Rent&locations=AD08DE8634&constructionYearMin=1990`),
+    ).toThrow(/constructionYearMin.*stopped/);
   });
 
   it('stays quiet about the tracking and view parameters every copied url carries', () => {
-    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
-    convertSearchUrlToRequest(
-      `${BASE}?distributionTypes=Rent&locations=AD08DE8634&serp_view=list&m=homepage_search&utm_source=newsletter&sr=1`,
-    );
-
-    expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
+    expect(() =>
+      convertSearchUrlToRequest(
+        `${BASE}?distributionTypes=Rent&locations=AD08DE8634&serp_view=list&m=homepage_search&utm_source=newsletter&sr=1`,
+      ),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- decode and validate Immowelt's base64url-encoded location objects
- translate saved radius boundaries to `criteria.location.polylines`
- preserve existing raw comma-separated place IDs and map `yearOfConstructionMin`
- stop malformed, invalid, or unsupported narrowing filters instead of silently widening searches
- continue ignoring only established tracking/view noise and `utm_*` parameters

## Root cause and impact

The JSON-BFF converter treated an encoded location object as a literal place ID, which caused HTTP 400 responses. Replacing it with a raw place ID avoided that error but discarded the saved radius boundary, while `yearOfConstructionMin` was also ignored. This change preserves those narrowing constraints and fails closed when exact translation is not possible.

The converter remains stateless. Job storage, notification behavior, UI schemas, and provider normalization are unchanged.

Fixes #424

## Validation

- focused Immowelt converter tests: 16 passed
- offline test suite: 172 files passed; 2,020 tests passed and 1 skipped
- ESLint and Prettier checks passed
- direct Immowelt provider verification returned HTTP 200 and matched the intercepted request criteria
- isolated `linux/amd64` image built and started healthy with zero restarts

The reproduction and validation evidence is sanitized; no private search URL values, coordinates, identifiers, database content, or runtime credentials are included.
