### PR TITLE
feat(listings): narrow provider filter to providers with results present

### DIFF
--- a/lib/api/routes/listingsRouter.js
+++ b/lib/api/routes/listingsRouter.js
@@ -114,26 +114,40 @@ export default async function listingsPlugin(fastify) {
             })),
           };
 
-    return withVerdict(
-      listingStorage.queryListings({
-        page: page ? parseInt(page, 10) : 1,
-        pageSize: pageSize ? parseInt(pageSize, 10) : 50,
-        freeTextFilter: freeTextFilter || null,
-        activityFilter: normalizedActivity,
-        jobNameFilter: jobFilter,
-        jobIdFilter: jobIdFilter,
-        providerFilter,
-        watchListFilter: normalizedWatch,
-        statusFilter: normalizedStatus,
-        hiddenOnly: normalizedHidden,
-        sortField: sortfield || null,
-        sortDir: sortdir === 'desc' ? 'desc' : 'asc',
-        affordabilityBand,
-        travelTimeFilter,
-        userId,
-        isAdmin: isAdminFn(request),
-      }),
-    );
+    const pageData = listingStorage.queryListings({
+      page: page ? parseInt(page, 10) : 1,
+      pageSize: pageSize ? parseInt(pageSize, 10) : 50,
+      freeTextFilter: freeTextFilter || null,
+      activityFilter: normalizedActivity,
+      jobNameFilter: jobFilter,
+      jobIdFilter: jobIdFilter,
+      providerFilter,
+      watchListFilter: normalizedWatch,
+      statusFilter: normalizedStatus,
+      hiddenOnly: normalizedHidden,
+      sortField: sortfield || null,
+      sortDir: sortdir === 'desc' ? 'desc' : 'asc',
+      affordabilityBand,
+      travelTimeFilter,
+      userId,
+      isAdmin: isAdminFn(request),
+    });
+
+    const availableProviders =
+      typeof listingStorage.getAvailableProviders === 'function'
+        ? listingStorage.getAvailableProviders({
+            jobId: jobIdFilter,
+            jobName: jobFilter,
+            userId,
+            isAdmin: isAdminFn(request),
+            hiddenOnly: normalizedHidden,
+          })
+        : [];
+
+    return withVerdict({
+      ...pageData,
+      availableProviders,
+    });
   });
 
   fastify.get('/map', async (request) => {

--- a/lib/services/storage/listingsStorage.js
+++ b/lib/services/storage/listingsStorage.js
@@ -302,6 +302,56 @@ export const getProviderDistributionForJobIds = (jobIds = []) => {
 
   return percentages;
 };
+/**
+ * Return the distinct provider identifiers that currently have non-deleted listings
+ * within the user's accessible scope (optionally filtered by a specific job).
+ *
+ * @param {Object} [params]
+ * @param {string|null} [params.jobId]
+ * @param {string|null} [params.jobName]
+ * @param {string|null} [params.userId]
+ * @param {boolean} [params.isAdmin]
+ * @param {boolean} [params.hiddenOnly]
+ * @returns {string[]}
+ */
+export const getAvailableProviders = ({
+  jobId = null,
+  jobName = null,
+  userId = null,
+  isAdmin = false,
+  hiddenOnly = false,
+} = {}) => {
+  const whereParts = [];
+  const params = { userId: userId || '__NO_USER__' };
+
+  if (!isAdmin) {
+    whereParts.push(USER_LISTING_SET_SCOPE_SQL);
+  }
+  if (jobId && String(jobId).trim().length > 0) {
+    params.jobId = String(jobId).trim();
+    whereParts.push('(l.job_id = @jobId)');
+  } else if (jobName && String(jobName).trim().length > 0) {
+    params.jobName = String(jobName).trim();
+    whereParts.push('(j.name = @jobName)');
+  }
+  if (hiddenOnly) {
+    whereParts.push('(l.manually_deleted = 1)');
+  } else {
+    whereParts.push('(l.manually_deleted = 0)');
+  }
+
+  const whereSql = whereParts.length ? `WHERE ${whereParts.join(' AND ')}` : '';
+  const rows = SqliteConnection.query(
+    `SELECT DISTINCT l.provider
+     FROM listings l
+            LEFT JOIN jobs j ON j.id = l.job_id
+     ${whereSql}
+     ORDER BY l.provider ASC`,
+    params,
+  );
+
+  return rows.map((r) => r.provider).filter(Boolean);
+};
 
 /**
  * Consecutive failed probes after which a listing counts as gone.

--- a/test/api/listingsAffordabilityFilter.test.js
+++ b/test/api/listingsAffordabilityFilter.test.js
@@ -10,6 +10,7 @@ import Fastify from 'fastify';
 // translation and nothing else.
 vi.mock('../../lib/services/storage/listingsStorage.js', () => ({
   queryListings: vi.fn(() => ({ totalNumber: 0, page: 1, result: [] })),
+  getAvailableProviders: vi.fn(() => []),
   getListingsForMap: vi.fn(() => []),
   getListingById: vi.fn(() => null),
   setListingNotes: vi.fn(() => 1),

--- a/test/storage/listingStatus.test.js
+++ b/test/storage/listingStatus.test.js
@@ -158,6 +158,33 @@ describe('listingsStorage.queryListings hiddenOnly', () => {
   });
 });
 
+describe('listingsStorage.getAvailableProviders', () => {
+  let listingsStorage;
+
+  beforeEach(async () => {
+    calls.execute.length = 0;
+    calls.query.length = 0;
+    sqliteMock.__queryHandler = null;
+    listingsStorage = await import('../../lib/services/storage/listingsStorage.js');
+  });
+
+  it('queries distinct providers excluding manually deleted by default', () => {
+    sqliteMock.__queryHandler = () => [{ provider: 'immoscout' }, { provider: 'immowelt' }];
+    const result = listingsStorage.getAvailableProviders({ userId: 'u1', isAdmin: true });
+    expect(result).toEqual(['immoscout', 'immowelt']);
+    expect(calls.query[0].sql).toMatch(/SELECT DISTINCT l\.provider/);
+    expect(calls.query[0].sql).toMatch(/\(l\.manually_deleted = 0\)/);
+  });
+
+  it('filters by jobId when jobId is provided', () => {
+    sqliteMock.__queryHandler = () => [{ provider: 'immoscout' }];
+    const result = listingsStorage.getAvailableProviders({ jobId: 'job-1', userId: 'u1', isAdmin: true });
+    expect(result).toEqual(['immoscout']);
+    expect(calls.query[0].sql).toMatch(/\(l\.job_id = @jobId\)/);
+    expect(calls.query[0].params.jobId).toBe('job-1');
+  });
+});
+
 describe('listingsStorage.restoreListingsById', () => {
   let listingsStorage;
 

--- a/test/ui/listingFilters.test.js
+++ b/test/ui/listingFilters.test.js
@@ -218,6 +218,26 @@ describe('listingFilters', () => {
       ]);
     });
 
+    it('narrows to providers for which results are present when availableProviders is provided', () => {
+      const jobs = [
+        { id: 'j1', name: 'Job 1', provider: [{ id: 'immoscout' }, { id: 'immowelt' }, { id: 'kleinanzeigen' }] },
+      ];
+      // Results only exist for immoscout
+      const result = filterConfiguredProviders(allProviders, jobs, null, null, ['immoscout']);
+      expect(result).toEqual([{ id: 'immoscout', name: 'ImmoScout24' }]);
+    });
+
+    it('preserves an active provider filter even if no results currently match it', () => {
+      const jobs = [
+        { id: 'j1', name: 'Job 1', provider: [{ id: 'immoscout' }] },
+      ];
+      const result = filterConfiguredProviders(allProviders, jobs, null, 'immowelt', ['immoscout']);
+      expect(result).toEqual([
+        { id: 'immoscout', name: 'ImmoScout24' },
+        { id: 'immowelt', name: 'Immowelt' },
+      ]);
+    });
+
     it('falls back to all providers when no jobs exist', () => {
       expect(filterConfiguredProviders(allProviders, [])).toEqual(allProviders);
       expect(filterConfiguredProviders(allProviders, null)).toEqual(allProviders);

--- a/test/ui/listingFilters.test.js
+++ b/test/ui/listingFilters.test.js
@@ -15,6 +15,7 @@ import {
   clearFilter,
   clearAllFilters,
   describeActiveFilters,
+  filterConfiguredProviders,
 } from '../../ui/src/services/listings/listingFilters.js';
 
 /** The URL state as the page opens it. @returns {Object} */
@@ -176,6 +177,60 @@ describe('listingFilters', () => {
     it('produces one chip per counted filter', () => {
       const values = { ...defaults(), provider: 'is24', status: 'applied', watch: true };
       expect(describeActiveFilters(values, { t })).toHaveLength(countActiveFilters(values));
+    });
+  });
+
+  describe('configured providers', () => {
+    const allProviders = [
+      { id: 'immoscout', name: 'ImmoScout24' },
+      { id: 'immowelt', name: 'Immowelt' },
+      { id: 'kleinanzeigen', name: 'Kleinanzeigen' },
+      { id: 'wgGesucht', name: 'WG-Gesucht' },
+    ];
+
+    it('restricts providers to those present in configured jobs', () => {
+      const jobs = [
+        { id: 'j1', name: 'Job 1', provider: [{ id: 'immoscout' }] },
+        { id: 'j2', name: 'Job 2', provider: [{ id: 'immowelt' }] },
+      ];
+      const result = filterConfiguredProviders(allProviders, jobs);
+      expect(result).toEqual([
+        { id: 'immoscout', name: 'ImmoScout24' },
+        { id: 'immowelt', name: 'Immowelt' },
+      ]);
+    });
+
+    it('narrows to the selected job when a job filter is active', () => {
+      const jobs = [
+        { id: 'j1', name: 'Job 1', provider: [{ id: 'immoscout' }] },
+        { id: 'j2', name: 'Job 2', provider: [{ id: 'immowelt' }] },
+      ];
+      const result = filterConfiguredProviders(allProviders, jobs, 'j1');
+      expect(result).toEqual([{ id: 'immoscout', name: 'ImmoScout24' }]);
+    });
+
+    it('preserves an active provider filter even if unconfigured in the current job', () => {
+      const jobs = [{ id: 'j1', name: 'Job 1', provider: [{ id: 'immoscout' }] }];
+      const result = filterConfiguredProviders(allProviders, jobs, 'j1', 'kleinanzeigen');
+      expect(result).toEqual([
+        { id: 'immoscout', name: 'ImmoScout24' },
+        { id: 'kleinanzeigen', name: 'Kleinanzeigen' },
+      ]);
+    });
+
+    it('falls back to all providers when no jobs exist', () => {
+      expect(filterConfiguredProviders(allProviders, [])).toEqual(allProviders);
+      expect(filterConfiguredProviders(allProviders, null)).toEqual(allProviders);
+    });
+
+    it('falls back to all providers when jobs have no configured providers', () => {
+      const jobs = [{ id: 'j1', name: 'Job 1', provider: [] }];
+      expect(filterConfiguredProviders(allProviders, jobs)).toEqual(allProviders);
+    });
+
+    it('handles empty or missing providers list safely', () => {
+      expect(filterConfiguredProviders([], [{ id: 'j1' }])).toEqual([]);
+      expect(filterConfiguredProviders(null, [{ id: 'j1' }])).toEqual([]);
     });
   });
 });

--- a/ui/src/components/listings/ListingsFilterPanel.jsx
+++ b/ui/src/components/listings/ListingsFilterPanel.jsx
@@ -36,6 +36,7 @@ import { useTranslation } from '../../services/i18n/i18n.jsx';
  * @param {(patch: Object) => void} props.onChange Applies a URL patch.
  * @param {{id: string, name: string}[]} [props.jobs]
  * @param {{id: string, name: string}[]} [props.providers]
+ * @param {string[]|null} [props.availableProviders]
  * @param {boolean} props.financeComplete
  * @param {string} props.affordabilityHelp
  * @param {boolean} props.hasAddresses
@@ -49,6 +50,7 @@ export default function ListingsFilterPanel({
   onChange,
   jobs = [],
   providers = [],
+  availableProviders = null,
   financeComplete,
   affordabilityHelp,
   hasAddresses,
@@ -56,7 +58,13 @@ export default function ListingsFilterPanel({
 }) {
   const t = useTranslation();
   const activeCount = countActiveFilters(values);
-  const visibleProviders = filterConfiguredProviders(providers, jobs, values.job, values.provider);
+  const visibleProviders = filterConfiguredProviders(
+    providers,
+    jobs,
+    values.job,
+    values.provider,
+    availableProviders,
+  );
 
 
   return (

--- a/ui/src/components/listings/ListingsFilterPanel.jsx
+++ b/ui/src/components/listings/ListingsFilterPanel.jsx
@@ -8,7 +8,13 @@ import { Radio, RadioGroup, Select } from '@douyinfe/semi-ui-19';
 import FilterSelect from './FilterSelect.jsx';
 import FilterDrawer, { FilterGroup, FilterHelp } from '../filters/FilterDrawer.jsx';
 import { COMMUTE_OPTIONS } from '../transit/travelTimeFormat.js';
-import { showValueOf, showPatch, clearAllFilters, countActiveFilters } from '../../services/listings/listingFilters.js';
+import {
+  showValueOf,
+  showPatch,
+  clearAllFilters,
+  countActiveFilters,
+  filterConfiguredProviders,
+} from '../../services/listings/listingFilters.js';
 import { useTranslation } from '../../services/i18n/i18n.jsx';
 
 /**
@@ -50,6 +56,8 @@ export default function ListingsFilterPanel({
 }) {
   const t = useTranslation();
   const activeCount = countActiveFilters(values);
+  const visibleProviders = filterConfiguredProviders(providers, jobs, values.job, values.provider);
+
 
   return (
     <FilterDrawer
@@ -162,7 +170,7 @@ export default function ListingsFilterPanel({
           value={values.provider}
           style={{ width: '100%' }}
         >
-          {providers?.map((provider) => (
+          {visibleProviders?.map((provider) => (
             <Select.Option key={provider.id} value={provider.id}>
               {provider.name}
             </Select.Option>

--- a/ui/src/components/listings/ListingsOverview.jsx
+++ b/ui/src/components/listings/ListingsOverview.jsx
@@ -426,6 +426,7 @@ const ListingsOverview = () => {
         onChange={setValues}
         jobs={jobs}
         providers={providers}
+        availableProviders={listingsData?.availableProviders}
         financeComplete={financeComplete}
         affordabilityHelp={affordabilityHelp}
         hasAddresses={hasAddresses}

--- a/ui/src/services/listings/listingFilters.js
+++ b/ui/src/services/listings/listingFilters.js
@@ -176,10 +176,13 @@ export function describeActiveFilters(values, { t, jobs = [], providers = [] }) 
   }));
 }
 /**
- * Restricts the available providers to those actually configured in the user's jobs,
- * so the filter dropdown only contains providers for which results can exist.
+ * Restricts the available providers to those for which results exist (or are configured
+ * in the user's jobs), so the filter dropdown only contains relevant providers.
  *
- * If a specific job is selected, only that job's configured providers are offered.
+ * If `availableProviders` (from listing search results) is provided and non-empty,
+ * it narrows to providers present in those results. Otherwise, it falls back to
+ * providers configured across the user's jobs (or the selected job).
+ *
  * When no jobs are configured yet or no providers can be derived, all providers are
  * preserved as a fallback. A currently active provider filter is always preserved.
  *
@@ -187,13 +190,29 @@ export function describeActiveFilters(values, { t, jobs = [], providers = [] }) 
  * @param {Array<{id: string, name?: string, provider?: Array<{id?: string, name?: string}>}>} [jobs]
  * @param {string|null} [selectedJobId]
  * @param {string|null} [currentProviderId]
+ * @param {string[]|null} [availableProviders] Distinct provider IDs that have results
  * @returns {{id: string, name: string}[]}
  */
-export function filterConfiguredProviders(providers = [], jobs = [], selectedJobId = null, currentProviderId = null) {
+export function filterConfiguredProviders(
+  providers = [],
+  jobs = [],
+  selectedJobId = null,
+  currentProviderId = null,
+  availableProviders = null,
+) {
   if (!Array.isArray(providers) || providers.length === 0) {
     return [];
   }
 
+  // 1. If concrete result providers from listings exist, prioritize them
+  if (Array.isArray(availableProviders) && availableProviders.length > 0) {
+    const resultProviderIds = new Set(availableProviders);
+    return providers.filter(
+      (provider) => resultProviderIds.has(provider.id) || (currentProviderId && provider.id === currentProviderId),
+    );
+  }
+
+  // 2. Otherwise fall back to job configurations
   if (!Array.isArray(jobs) || jobs.length === 0) {
     return providers;
   }

--- a/ui/src/services/listings/listingFilters.js
+++ b/ui/src/services/listings/listingFilters.js
@@ -175,3 +175,52 @@ export function describeActiveFilters(values, { t, jobs = [], providers = [] }) 
     label: labels[key](),
   }));
 }
+/**
+ * Restricts the available providers to those actually configured in the user's jobs,
+ * so the filter dropdown only contains providers for which results can exist.
+ *
+ * If a specific job is selected, only that job's configured providers are offered.
+ * When no jobs are configured yet or no providers can be derived, all providers are
+ * preserved as a fallback. A currently active provider filter is always preserved.
+ *
+ * @param {{id: string, name: string}[]} [providers]
+ * @param {Array<{id: string, name?: string, provider?: Array<{id?: string, name?: string}>}>} [jobs]
+ * @param {string|null} [selectedJobId]
+ * @param {string|null} [currentProviderId]
+ * @returns {{id: string, name: string}[]}
+ */
+export function filterConfiguredProviders(providers = [], jobs = [], selectedJobId = null, currentProviderId = null) {
+  if (!Array.isArray(providers) || providers.length === 0) {
+    return [];
+  }
+
+  if (!Array.isArray(jobs) || jobs.length === 0) {
+    return providers;
+  }
+
+  const relevantJobs = selectedJobId
+    ? jobs.filter((j) => j?.id === selectedJobId || j?.name === selectedJobId)
+    : jobs;
+
+  const targetJobs = relevantJobs.length > 0 ? relevantJobs : jobs;
+
+  const configuredProviderIds = new Set();
+  for (const job of targetJobs) {
+    if (Array.isArray(job?.provider)) {
+      for (const p of job.provider) {
+        const id = p?.id || p?.name;
+        if (id) {
+          configuredProviderIds.add(id);
+        }
+      }
+    }
+  }
+
+  if (configuredProviderIds.size === 0) {
+    return providers;
+  }
+
+  return providers.filter(
+    (provider) => configuredProviderIds.has(provider.id) || (currentProviderId && provider.id === currentProviderId),
+  );
+}


### PR DESCRIPTION
Fixes #420

### Summary of Changes
- **Result-aware provider filtering**: The Provider dropdown in the Listings filter panel now narrows specifically to providers for which non-deleted results are present in the user's listings.
- **Job & scope awareness**:
  - Distinct providers with listings are queried within the user's accessible scope on `/api/listings/table`.
  - When filtering by a specific job, it further narrows to providers with listings in that job.
- **Safe fallbacks**:
  - If no results exist yet for configured jobs, it falls back to providers configured across the user's jobs.
  - If an unrepresented provider is currently active in the URL/filter state, it is preserved in the dropdown so active filters remain visible and clearable.
  - If no jobs or listings exist, all providers are safely preserved as a fallback.
- **Tests**:
  - Added storage test in `test/storage/listingStatus.test.js` for `getAvailableProviders`.
  - Added unit tests in `test/ui/listingFilters.test.js` for `filterConfiguredProviders` with `availableProviders`.

### Verification
- `yarn test:offline` (172/172 test suites passed, 2,025 tests)
- `yarn lint` (0 errors)