### PR TITLE
Retry a geocode without the trailing bracket when nothing was found

### DIFF
--- a/lib/services/geocoding/geoCodingService.js
+++ b/lib/services/geocoding/geoCodingService.js
@@ -10,6 +10,25 @@ import { getProviderIdsForCountries } from '../providers/providerCountries.js';
 import logger from '../logger.js';
 
 /**
+ * An address with a trailing parenthesis removed, or null when there is nothing to remove.
+ *
+ * Kleinanzeigen writes how far a listing is from the searched point into the address, so what
+ * reaches the geocoder is `40217 Unterbilk (0.6 km)`. Nominatim treats the distance as part of the
+ * place name and answers "no such place", which is not an error: the listing is stored without
+ * coordinates, so no area filter can judge it and no travel time is computed.
+ *
+ * Only the last parenthesis, only at the end, and only if something is left. Anything a portal puts
+ * after the address is the portal talking about the listing rather than naming the place.
+ *
+ * @param {string} address
+ * @returns {string|null}
+ */
+function withoutTrailingParenthesis(address) {
+  const trimmed = address.replace(/\s*\([^()]*\)\s*$/, '').trim();
+  return trimmed.length > 0 && trimmed !== address.trim() ? trimmed : null;
+}
+
+/**
  * Geocodes an address using Nominatim or cached results from the database.
  *
  * @param {string} address - The address to geocode.
@@ -33,7 +52,27 @@ export async function geocodeAddress(address, countries = DEFAULT_COUNTRIES) {
     }
 
     // 2. If not, use Nominatim
-    return await nominatimGeocode(address, countries);
+    const coordinates = await nominatimGeocode(address, countries);
+
+    // 3. Nothing found. Try again without whatever the portal appended in brackets, which is the
+    // difference between a listing on the map and one that only shows its address.
+    //
+    // Only when the answer was "looked, found nothing". A null means the geocoder could not be
+    // reached or is standing off after a 429, and asking again would double the requests exactly
+    // when Nominatim has said to stop. Never when the first answer worked, either: `40211
+    // Stadtmitte (1 km)` resolves to Düsseldorf as written and to Berlin without the distance,
+    // there being a Stadtmitte in both. Since `_filterByArea` deletes listings that fall outside
+    // the area, replacing a good answer with a wrong one would delete the listing rather than
+    // merely misplace its pin.
+    if (coordinates != null && coordinates.lat === -1 && coordinates.lng === -1) {
+      const shorter = withoutTrailingParenthesis(address);
+      if (shorter != null) {
+        logger.debug(`No coordinates for '${address}'. Trying '${shorter}'.`);
+        return await nominatimGeocode(shorter, countries);
+      }
+    }
+
+    return coordinates;
   } catch (error) {
     logger.error('Error during geocoding:', error);
     return null;

--- a/test/services/geocoding/geocodeRetryOnEmpty.test.js
+++ b/test/services/geocoding/geocodeRetryOnEmpty.test.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/services/logger.js', () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../../lib/services/storage/listingsStorage.js', () => ({
+  getGeocoordinatesByAddress: vi.fn(() => null),
+}));
+vi.mock('../../../lib/services/providers/providerCountries.js', () => ({
+  getProviderIdsForCountries: vi.fn(async () => []),
+}));
+
+const NOT_FOUND = { lat: -1, lng: -1 };
+const geocodeMock = vi.fn();
+vi.mock('../../../lib/services/geocoding/client/nominatimClient.js', () => ({
+  geocode: geocodeMock,
+  isPaused: () => false,
+}));
+
+const { geocodeAddress } = await import('../../../lib/services/geocoding/geoCodingService.js');
+
+/** The addresses handed to the geocoder, in order. */
+const asked = () => geocodeMock.mock.calls.map((call) => call[0]);
+
+beforeEach(() => {
+  geocodeMock.mockReset();
+});
+
+/**
+ * Retrying an address that Nominatim could not find, without the trailing parenthesis.
+ *
+ * Kleinanzeigen writes how far a listing is from the searched point into the address itself, so what
+ * reaches the geocoder looks like `40217 Unterbilk (0.6 km)`. Nominatim reads that as part of the
+ * place name and answers "no such place", which is not an error: the listing is stored with no
+ * coordinates, no area filter can judge it and no travel time is computed. The same address without
+ * the distance resolves.
+ *
+ * Only on an empty answer, never on one that worked. `40211 Stadtmitte (1 km)` resolves to
+ * Düsseldorf as written, and to Berlin without the distance - there is a Stadtmitte in both. Since
+ * `_filterByArea` deletes listings that fall outside the area, replacing a good answer with a wrong
+ * one would not merely misplace a pin, it would delete the listing.
+ */
+describe('geocodeAddress retrying without a trailing parenthesis', () => {
+  it('retries an address it could not find, without the parenthesis', async () => {
+    geocodeMock.mockResolvedValueOnce(NOT_FOUND).mockResolvedValueOnce({ lat: 51.2127, lng: 6.7742 });
+
+    await expect(geocodeAddress('40217 Unterbilk (0.6 km)', ['de'])).resolves.toEqual({
+      lat: 51.2127,
+      lng: 6.7742,
+    });
+    expect(asked()).toEqual(['40217 Unterbilk (0.6 km)', '40217 Unterbilk']);
+  });
+
+  it('leaves an address that resolved alone, so a good answer is never replaced by a worse one', async () => {
+    geocodeMock.mockResolvedValueOnce({ lat: 51.2219, lng: 6.7844 });
+
+    await expect(geocodeAddress('40211 Stadtmitte (1 km)', ['de'])).resolves.toEqual({
+      lat: 51.2219,
+      lng: 6.7844,
+    });
+    expect(asked()).toEqual(['40211 Stadtmitte (1 km)']);
+  });
+
+  it('reports not found when the retry cannot find it either', async () => {
+    geocodeMock.mockResolvedValue(NOT_FOUND);
+
+    await expect(geocodeAddress('Nowhere at all (2 km)', ['de'])).resolves.toEqual(NOT_FOUND);
+    expect(asked()).toHaveLength(2);
+  });
+
+  it('does not retry an address with no parenthesis to drop', async () => {
+    geocodeMock.mockResolvedValue(NOT_FOUND);
+
+    await geocodeAddress('40217 Unterbilk', ['de']);
+    expect(asked()).toEqual(['40217 Unterbilk']);
+  });
+
+  // A null answer means the geocoder could not be reached, or is standing off after a 429. Asking
+  // again would double the requests exactly when Nominatim has said to stop.
+  it('does not retry when the geocoder never answered', async () => {
+    geocodeMock.mockResolvedValue(null);
+
+    await expect(geocodeAddress('40217 Unterbilk (0.6 km)', ['de'])).resolves.toBeNull();
+    expect(asked()).toEqual(['40217 Unterbilk (0.6 km)']);
+  });
+
+  it('does not retry an address that is nothing but a parenthesis', async () => {
+    geocodeMock.mockResolvedValue(NOT_FOUND);
+
+    await geocodeAddress('(0.6 km)', ['de']);
+    expect(asked()).toEqual(['(0.6 km)']);
+  });
+
+  it('drops only the last parenthesis, and only at the end', async () => {
+    geocodeMock.mockResolvedValueOnce(NOT_FOUND).mockResolvedValueOnce({ lat: 1, lng: 2 });
+
+    await geocodeAddress('Musterstr. 1 (Hinterhaus), 12345 Berlin (3 km)', ['de']);
+    expect(asked()[1]).toBe('Musterstr. 1 (Hinterhaus), 12345 Berlin');
+  });
+});


### PR DESCRIPTION
### The problem

Kleinanzeigen writes how far a listing is from the searched point into the address itself, so what
reaches the geocoder is `40217 Unterbilk (0.6 km)`. Nominatim reads the distance as part of the place
name and answers "no such place".

That answer is not an error, so nothing retries and nothing reports it. The listing is stored with no
coordinates, `_filterByArea` cannot judge it, and no travel time is computed. Its address on its own
resolves fine.

### The three cases

From the kleinanzeigen fixture already in the repo, geocoded as they stand and again without the
bracket:

| address | as written | without the bracket |
|---|---|---|
| `40235 Flingern Nord (3 km)` | 51.2314,6.8132 | 51.2311,6.8249 |
| `40211 Stadtmitte (1 km)` | 51.2219,6.7844 | 52.5121,13.3897 |
| `40217 Unterbilk (0.6 km)` | **not found** | 51.2127,6.7742 |

The middle row is why this retries only on an empty answer. `40211 Stadtmitte` is Düsseldorf as
written and Berlin without the distance, there being one in both, and since `_filterByArea` deletes
listings outside the area, a wrong answer would delete the listing rather than misplace its pin.

A `null` does not retry either: the geocoder was unreachable or is standing off after a 429, and a
second request is the last thing it needs.

### Scope

One function in `geoCodingService.js`, on the path every geocode already takes. Only the last
bracket, only at the end, only when something is left in front of it. No provider file changes.

Verified against live Nominatim: `40217 Unterbilk (0.6 km)` goes from nothing to 51.2127,6.7742 and
`40211 Stadtmitte (1 km)` stays in Düsseldorf. 7 tests, suite green at 2205.
