### PR TITLE
Leave a listing alone when the provider already located it

### DIFF
--- a/lib/FredyPipelineExecutioner.js
+++ b/lib/FredyPipelineExecutioner.js
@@ -34,6 +34,32 @@ import { addressesWithBudget, exceedsCommuteBudget, normalizeCommuteFilter } fro
 /** @import { Browser } from './types/browser.js' */
 
 /**
+ * Whether a listing already knows where it is.
+ *
+ * `ParsedListing` has carried optional coordinates all along, and a provider reading a JSON API
+ * often gets them for nothing and to the metre. Geocoding on the strength of `address` alone then
+ * assigned over them, so an exact position was replaced by whatever Nominatim makes of the address
+ * text - for a portal that writes a district rather than a street, the middle of the district. A
+ * worse coordinate, bought with a request against a geocoder that allows one per second.
+ *
+ * Both halves have to be there. Half a coordinate is not a position, and skipping on one of the two
+ * would leave a listing with a latitude and no longitude, which puts it nowhere.
+ *
+ * `-1/-1` does not count either. That is the "looked, found nothing" answer a previous geocode
+ * stored, not a place, and a listing carrying it is exactly one that should be tried again.
+ *
+ * @param {ParsedListing} listing
+ * @returns {boolean}
+ */
+function isLocated(listing) {
+  const { latitude, longitude } = listing;
+  if (typeof latitude !== 'number' || typeof longitude !== 'number') {
+    return false;
+  }
+  return !(latitude === -1 && longitude === -1);
+}
+
+/**
  * Runtime orchestrator for fetching, normalizing, filtering, deduplicating, storing,
  * and notifying about new listings from a configured provider.
  *
@@ -184,7 +210,7 @@ class FredyPipelineExecutioner {
     // Resolved once: every listing in this batch came from the same provider.
     const countries = await getCountriesForProvider(this._providerId);
     for (const listing of newListings) {
-      if (listing.address) {
+      if (listing.address && !isLocated(listing)) {
         const coords = await geocodeAddress(listing.address, countries);
         if (coords && coords.lat !== -1 && coords.lng !== -1) {
           listing.latitude = coords.lat;

--- a/test/mocks/mockStore.js
+++ b/test/mocks/mockStore.js
@@ -17,6 +17,37 @@ export const getGeocoordinatesByAddress = (any) => {
   return null;
 };
 
+/**
+ * Every address the pipeline asked the geocoder about, in order.
+ *
+ * A test that cares whether a geocode happened at all needs to see the absence of a call, which a
+ * plain stub cannot show.
+ * @type {string[]}
+ */
+export const geocodedAddresses = [];
+
+/** What the stand-in geocoder answers. Set by a test that needs coordinates back. */
+export let geocodeResult = null;
+
+/**
+ * @param {{lat: number, lng: number}|null} result
+ * @returns {void}
+ */
+export function setGeocodeResult(result) {
+  geocodeResult = result;
+}
+
+/**
+ * Stands in for `geoCodingService.geocodeAddress`, recording what it was asked.
+ *
+ * @param {string} address
+ * @returns {{lat: number, lng: number}|null}
+ */
+export const geocodeAddress = (address) => {
+  geocodedAddresses.push(address);
+  return geocodeResult;
+};
+
 let userSettings = null;
 export function setUserSettings(settings) {
   userSettings = settings;

--- a/test/pipeline_providerCoordinates.test.js
+++ b/test/pipeline_providerCoordinates.test.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mockFredy } from './utils.js';
+import * as mockStore from './mocks/mockStore.js';
+
+/**
+ * A provider that already knows where a listing is.
+ *
+ * `ParsedListing` has carried optional `latitude` and `longitude` all along, and a provider reading
+ * a JSON API often gets them for nothing, to the metre. The geocode step did not look: it geocoded
+ * on the strength of `address` alone and assigned over whatever was there. So a provider handing
+ * over an exact position had it replaced by whatever Nominatim makes of the address text, which for
+ * a portal that writes a district rather than a street is the middle of the district. That is a
+ * worse coordinate, bought with a request against a geocoder that allows one per second.
+ */
+function configFor(listing) {
+  return {
+    url: 'http://example.com',
+    getListings: () => Promise.resolve([listing]),
+    normalize: (l) => l,
+    filter: () => true,
+    crawlFields: { id: 'id', title: 'title', address: 'address', price: 'price' },
+    requiredFieldNames: ['id', 'title', 'address', 'price'],
+  };
+}
+
+const job = { id: 'test-job', notificationAdapter: null, specFilter: null, spatialFilter: null };
+
+/**
+ * Run one listing through the pipeline and hand back what it looked like afterwards.
+ *
+ * @param {Object} listing
+ * @returns {Promise<Object>}
+ */
+async function run(listing) {
+  const Fredy = await mockFredy();
+  const fredy = new Fredy(configFor(listing), job, 'test-provider', { checkAndAddEntry: () => false }, undefined);
+  try {
+    await fredy.execute();
+  } catch {
+    // NoNewListingsWarning is control flow here, and the geocode step has already run.
+  }
+  return listing;
+}
+
+beforeEach(() => {
+  mockStore.geocodedAddresses.length = 0;
+  mockStore.setGeocodeResult({ lat: 51.2219, lng: 6.7844 });
+});
+
+describe('the pipeline leaves a listing the provider already located', () => {
+  it('does not geocode it', async () => {
+    await run({
+      id: '1',
+      title: 't',
+      price: '100',
+      link: 'http://example.com/1',
+      address: '40217 Unterbilk',
+      latitude: 51.2127,
+      longitude: 6.7742,
+    });
+    expect(mockStore.geocodedAddresses).toEqual([]);
+  });
+
+  it("keeps the provider's coordinates", async () => {
+    const listing = await run({
+      id: '1',
+      title: 't',
+      price: '100',
+      link: 'http://example.com/1',
+      address: '40217 Unterbilk',
+      latitude: 51.2127,
+      longitude: 6.7742,
+    });
+    expect(listing).toMatchObject({ latitude: 51.2127, longitude: 6.7742 });
+  });
+
+  it('still geocodes a listing that carries no coordinates', async () => {
+    const listing = await run({
+      id: '1',
+      title: 't',
+      price: '100',
+      link: 'http://example.com/1',
+      address: '40217 Unterbilk',
+    });
+    expect(mockStore.geocodedAddresses).toEqual(['40217 Unterbilk']);
+    expect(listing).toMatchObject({ latitude: 51.2219, longitude: 6.7844 });
+  });
+
+  // Half a coordinate is not a position. Skipping on one of the two would leave the listing with a
+  // latitude and no longitude, which puts it nowhere and cannot be recovered later.
+  it('geocodes a listing that carries only one of the two', async () => {
+    await run({
+      id: '1',
+      title: 't',
+      price: '100',
+      link: 'http://example.com/1',
+      address: '40217 Unterbilk',
+      latitude: 51.2127,
+    });
+    expect(mockStore.geocodedAddresses).toEqual(['40217 Unterbilk']);
+  });
+
+  it('geocodes a listing whose coordinates are the not-found sentinel', async () => {
+    await run({
+      id: '1',
+      title: 't',
+      price: '100',
+      link: 'http://example.com/1',
+      address: '40217 Unterbilk',
+      latitude: -1,
+      longitude: -1,
+    });
+    expect(mockStore.geocodedAddresses).toEqual(['40217 Unterbilk']);
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,7 +17,7 @@ export const sseEvents = [];
 vi.mock('../lib/services/storage/listingsStorage.js', () => mockStore);
 vi.mock('../lib/services/storage/settingsStorage.js', () => mockStore);
 vi.mock('../lib/services/geocoding/geoCodingService.js', () => ({
-  geocodeAddress: mockStore.getGeocoordinatesByAddress,
+  geocodeAddress: mockStore.geocodeAddress,
 }));
 vi.mock('../lib/services/storage/jobStorage.js', () => ({
   getJob: (jobKey) => ({ id: jobKey, userId: 'user1' }),


### PR DESCRIPTION
### The problem

`ParsedListing` has carried optional `latitude` and `longitude` all along, and a provider reading a
JSON API often gets them for nothing and to the metre. The geocode step never looked: it geocoded on
the strength of `address` alone and assigned over whatever was already there.

So a provider handing over an exact position had it replaced by whatever Nominatim makes of the
address text. For a portal that writes a district rather than a street, that is the middle of the
district — a worse coordinate, bought with a request against a geocoder that allows one per second,
once per listing.

### What counts as located

Both halves, and not the not-found sentinel:

| listing carries | geocoded? |
|---|---|
| no coordinates | yes |
| `latitude` only | yes — half a coordinate is not a position |
| `-1 / -1` | yes — that is a previous "found nothing", not a place |
| both, real | **no** |

### Scope

One guard in `_geocode`. Nothing changes for the providers in the tree, none of which supply
coordinates — this only stops the pipeline discarding work a future provider does for free.

The test harness grows a geocoder that records what it was asked: the behaviour to prove is the
absence of a call, and a plain stub cannot show that. 5 tests, suite green at 2203.
