### PR TITLE
feat(mcp): add tool annotations to the MCP tools

### DIFF
--- a/lib/mcp/mcpAdapter.js
+++ b/lib/mcp/mcpAdapter.js
@@ -3,10 +3,6 @@
  * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
  */
 
-/*
- * Copyright (c) 2026 by Christian Kellner.
- * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
- */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { queryJobs, getJob } from '../services/storage/jobStorage.js';
@@ -75,6 +71,7 @@ export function createMcpServer() {
         .describe('Results per page (default: 50, max: 1000). Start with the default and paginate if needed.'),
       filter: z.string().optional().describe('Free-text filter on job name'),
     },
+    { title: 'List search jobs', readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     async ({ page, pageSize, filter }, extra) => {
       const { user, error } = authenticateToolCall(extra, 'list_jobs');
       if (error) return normalizeError(error, 'list_jobs');
@@ -101,6 +98,7 @@ export function createMcpServer() {
     {
       jobId: z.string().describe('The job ID to retrieve'),
     },
+    { title: 'Get job details', readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     async ({ jobId }, extra) => {
       const { user, error } = authenticateToolCall(extra, 'get_job');
       if (error) return normalizeError(error, 'get_job');
@@ -170,6 +168,7 @@ export function createMcpServer() {
           'Filter by user-set status. "applied", "rejected", or "accepted" return only listings with that status; "none" returns only listings without a status set.',
         ),
     },
+    { title: 'Search listings', readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     async (
       {
         page,
@@ -223,6 +222,7 @@ export function createMcpServer() {
     {
       listingId: z.string().describe('The listing ID to retrieve'),
     },
+    { title: 'Get listing details', readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     async ({ listingId }, extra) => {
       const { user, error } = authenticateToolCall(extra, 'get_listing');
       if (error) return normalizeError(error, 'get_listing');
@@ -243,6 +243,7 @@ export function createMcpServer() {
     {
       listingId: z.string().describe('The listing ID whose photo to fetch'),
     },
+    { title: 'Get listing photo', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ listingId }, extra) => {
       const { user, error } = authenticateToolCall(extra, 'get_photo_for_listing');
       if (error) return normalizeError(error, 'get_photo_for_listing');
@@ -381,6 +382,7 @@ export function createMcpServer() {
       netIncome: z.number().optional().describe('Combined monthly net income, overriding the saved profile'),
       livingCosts: z.number().optional().describe('Monthly living costs excluding rent'),
     },
+    { title: 'Calculate financing', readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     async (args, extra) => {
       const { user, error } = authenticateToolCall(extra, 'calculate_financing');
       if (error) return normalizeError(error, 'calculate_financing');
@@ -454,11 +456,17 @@ export function createMcpServer() {
   );
 
   // ── get_current_date_ime ─────────────────────────────────────────────────────
-  server.tool('get_current_date_time', 'Returns the current date and time.', {}, () => {
-    return {
-      content: [{ type: 'text', text: `Timestring: ${new Date().toLocaleString()}, MS since 1970: ${Date.now()}` }],
-    };
-  });
+  server.tool(
+    'get_current_date_time',
+    'Returns the current date and time.',
+    {},
+    { title: 'Current date & time', readOnlyHint: true, idempotentHint: false, openWorldHint: false },
+    () => {
+      return {
+        content: [{ type: 'text', text: `Timestring: ${new Date().toLocaleString()}, MS since 1970: ${Date.now()}` }],
+      };
+    },
+  );
 
   return server;
 }

--- a/test/api/mcpAdapterAnnotations.test.js
+++ b/test/api/mcpAdapterAnnotations.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../../lib/mcp/mcpAdapter.js';
+
+/** Drive the real server over an in-memory transport and return tools keyed by name. */
+async function listTools() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  const { tools } = await client.listTools();
+  await client.close();
+  return Object.fromEntries(tools.map((tool) => [tool.name, tool]));
+}
+
+const ALL_TOOLS = [
+  'list_jobs',
+  'get_job',
+  'list_listings',
+  'get_listing',
+  'get_photo_for_listing',
+  'calculate_financing',
+  'get_current_date_time',
+];
+
+describe('MCP tool annotations', () => {
+  it('advertises every tool as read-only, so a client never warns about side effects', async () => {
+    const tools = await listTools();
+    for (const name of ALL_TOOLS) {
+      expect(tools[name]?.annotations?.readOnlyHint, `${name}.readOnlyHint`).toBe(true);
+    }
+  });
+
+  it('gives each tool a human title', async () => {
+    const tools = await listTools();
+    for (const name of ALL_TOOLS) {
+      expect(typeof tools[name]?.annotations?.title, `${name}.title`).toBe('string');
+    }
+    expect(tools.get_listing.annotations.title).toBe('Get listing details');
+  });
+
+  it('flags the remote photo fetch as open-world while local queries are closed-world', async () => {
+    const tools = await listTools();
+    expect(tools.get_photo_for_listing.annotations.openWorldHint).toBe(true);
+    expect(tools.list_listings.annotations.openWorldHint).toBe(false);
+    expect(tools.calculate_financing.annotations.openWorldHint).toBe(false);
+  });
+
+  it('marks the clock as non-idempotent and stable queries as idempotent', async () => {
+    const tools = await listTools();
+    expect(tools.get_current_date_time.annotations.idempotentHint).toBe(false);
+    expect(tools.list_jobs.annotations.idempotentHint).toBe(true);
+    expect(tools.get_job.annotations.idempotentHint).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds MCP [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations) to all seven Fredy MCP tools. Every tool is a read-only query, but the tool list carried no annotations, so a client had to assume calling them might change state (and some clients surface a warning/consent for un-annotated tools).

## Annotations

| tool | readOnlyHint | idempotentHint | openWorldHint | title |
| --- | --- | --- | --- | --- |
| `list_jobs` | ✅ | ✅ | — | List search jobs |
| `get_job` | ✅ | ✅ | — | Get job details |
| `list_listings` | ✅ | ✅ | — | Search listings |
| `get_listing` | ✅ | ✅ | — | Get listing details |
| `get_photo_for_listing` | ✅ | ✅ | ✅ | Get listing photo |
| `calculate_financing` | ✅ | ✅ | — | Calculate financing |
| `get_current_date_time` | ✅ | ❌ | — | Current date & time |

Rationale:
- **readOnlyHint** is true everywhere — no tool mutates Fredy state.
- **idempotentHint** is false only for `get_current_date_time`, whose result changes between identical calls.
- **openWorldHint** is true only for `get_photo_for_listing`, which `fetch()`es the image from a remote host; the rest read the local database.

Annotations are passed via the existing `server.tool(name, description, schema, annotations, handler)` overload, keeping the change consistent with the current registration style.

## Testing

New `test/api/mcpAdapterAnnotations.test.js` drives the real server over an in-memory transport and asserts the annotations surface through `tools/list`. `TEST_MODE=offline npx vitest run test/api/mcpAdapterAnnotations.test.js` — 4 passing. Lint/format/copyright hooks pass.