### PR TITLE
feat(mcp): expose internet and mobile coverage in the MCP tools

### DIFF
--- a/lib/mcp/mcpAdapter.js
+++ b/lib/mcp/mcpAdapter.js
@@ -22,6 +22,7 @@ import { computeFinanceResult } from '../services/finance/calculate.js';
 import { normalizeProfile } from '../services/finance/profile.js';
 import { computeBudget, netIncomeOf, scoreRentListing } from '../services/finance/affordability.js';
 import { DEAL_TYPES } from '../services/dealType.js';
+import { filterMask, TECHNOLOGIES, OPERATOR_CODES } from '../services/connectivity/mobileBits.js';
 
 /**
  * Create a configured MCP server instance with all Fredy tools registered.
@@ -49,8 +50,9 @@ export function createMcpServer() {
         'Fredy MCP Server - query real estate jobs and listings. ' +
         'All timestamps are unix timestamps in milliseconds (e.g. 1772008362564). ' +
         'Use list_jobs to browse jobs, get_job for details, ' +
-        'list_listings to search listings (supports time filters like createdAfter/createdBefore), ' +
-        'get_listing for full details of a single listing, ' +
+        'list_listings to search listings (supports time filters like createdAfter/createdBefore and ' +
+        'connectivity filters like minDownMbit/fiberOnly/mobileTech), ' +
+        'get_listing for full details of a single listing (including internet and mobile coverage), ' +
         'and calculate_financing to work out whether a listing is affordable (German mortgage model). ' +
         'Responses are formatted as markdown with a summary, data (tables for lists, key-value for details), and pagination info. ' +
         'Always present results to the user as soon as you have them - do NOT call the tool again unless you need additional pages or different data.',
@@ -167,6 +169,21 @@ export function createMcpServer() {
         .describe(
           'Filter by user-set status. "applied", "rejected", or "accepted" return only listings with that status; "none" returns only listings without a status set.',
         ),
+      minDownMbit: z
+        .number()
+        .optional()
+        .describe('Only include listings whose fixed-line downstream is at least this many Mbit/s (e.g. 100).'),
+      fiberOnly: z.boolean().optional().describe('When true, only listings with fibre to the building or home.'),
+      mobileTech: z
+        .enum(TECHNOLOGIES)
+        .optional()
+        .describe('Require mobile coverage of this technology at the address (2g, 4g, 5g, or 5g_sa).'),
+      mobileOperator: z
+        .enum(OPERATOR_CODES)
+        .optional()
+        .describe(
+          'Narrow mobileTech to a single German operator: dt (Telekom), vf (Vodafone), tf (O2 / Telefónica), ee (1&1). Ignored without mobileTech.',
+        ),
     },
     { title: 'Search listings', readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     async (
@@ -184,6 +201,10 @@ export function createMcpServer() {
         sortField,
         sortDir,
         status,
+        minDownMbit,
+        fiberOnly,
+        mobileTech,
+        mobileOperator,
       },
       extra,
     ) => {
@@ -192,6 +213,7 @@ export function createMcpServer() {
 
       const safePage = page ?? 1;
       const safePageSize = pageSize ?? 50;
+      const mobileMask = mobileTech ? filterMask(mobileTech, mobileOperator ?? null) : null;
 
       const result = queryListings({
         page: safePage,
@@ -207,6 +229,9 @@ export function createMcpServer() {
         sortField: sortField ?? null,
         sortDir: sortDir ?? 'desc',
         statusFilter: status,
+        connectivityMinDown: minDownMbit ?? null,
+        connectivityFiberOnly: fiberOnly === true,
+        connectivityMobileMask: mobileMask,
         userId: user.id,
         isAdmin: user.isAdmin,
       });

--- a/lib/mcp/mcpNormalizer.js
+++ b/lib/mcp/mcpNormalizer.js
@@ -21,6 +21,66 @@
  */
 
 import { formatTravelTimes } from '../utils/formatTravelTimes.js';
+import { OPERATORS, OPERATOR_CODES, TECHNOLOGIES } from '../services/connectivity/mobileBits.js';
+
+const TECH_LABELS = { '2g': '2G', '4g': '4G', '5g': '5G', '5g_sa': '5G-SA' };
+
+/**
+ * One-line summary of a listing's mobile coverage, newest technology first, naming the operators
+ * that offer each. Returns null when nothing is covered so callers can omit the line entirely.
+ *
+ * @param {{neutral?: Record<string, boolean>, operators?: Record<string, Record<string, boolean>>}|null} mobile
+ * @returns {string|null}
+ */
+function formatMobileCoverage(mobile) {
+  if (mobile == null) return null;
+  const parts = [];
+  for (const tech of [...TECHNOLOGIES].reverse()) {
+    if (!mobile.neutral?.[tech]) continue;
+    const operators = OPERATOR_CODES.filter((code) => mobile.operators?.[code]?.[tech]).map((code) => OPERATORS[code]);
+    const who =
+      operators.length === 0
+        ? 'available'
+        : operators.length === OPERATOR_CODES.length
+          ? 'all operators'
+          : operators.join(', ');
+    parts.push(`${TECH_LABELS[tech]} (${who})`);
+  }
+  return parts.length > 0 ? parts.join(' · ') : null;
+}
+
+/**
+ * The markdown lines describing a listing's fixed-line and mobile connectivity, or '' when the
+ * listing has not been enriched. Reads the parsed `connectivity` JSON that getListingById attaches.
+ *
+ * @param {{maxDownMbit?: number|null, fiber?: boolean, mobile?: object|null}|null|undefined} connectivity
+ * @returns {string}
+ */
+function formatConnectivity(connectivity) {
+  if (connectivity == null) return '';
+  let md = '';
+  if (connectivity.maxDownMbit != null) {
+    md += `- **Downstream:** up to ${connectivity.maxDownMbit} Mbit/s\n`;
+  }
+  md += `- **Fibre to the building:** ${connectivity.fiber ? 'yes' : 'no'}\n`;
+  const mobile = formatMobileCoverage(connectivity.mobile);
+  if (mobile != null) {
+    md += `- **Mobile coverage:** ${mobile}\n`;
+  }
+  return md;
+}
+
+/**
+ * Compact fixed-line cell for the listings table: downstream and a fibre marker, from the flat
+ * `connectivity_*` columns that SELECT l.* carries on every list row.
+ *
+ * @param {{connectivity_max_down?: number|null, connectivity_fiber?: number|null}} listing
+ * @returns {string}
+ */
+function internetCell(listing) {
+  if (listing.connectivity_max_down == null) return '–';
+  return `${listing.connectivity_max_down} Mbit/s${listing.connectivity_fiber ? ' · fibre' : ''}`;
+}
 
 /**
  * Wrap a markdown string as an MCP text content result.
@@ -127,10 +187,10 @@ export function normalizeListListings(queryResult, { page, pageSize }) {
   md += '\n\n';
 
   if (listings.length > 0) {
-    md += `| ID | Title | Address | Price | Deal | Size | Provider | Active | Status | Created | Job |\n`;
-    md += `|----|-------|---------|-------|------|------|----------|--------|--------|---------|-----|\n`;
+    md += `| ID | Title | Address | Price | Deal | Size | Provider | Internet | Active | Status | Created | Job |\n`;
+    md += `|----|-------|---------|-------|------|------|----------|----------|--------|--------|---------|-----|\n`;
     for (const l of listings) {
-      md += `| ${cell(l.id)} | ${cell(l.title)} | ${cell(l.address)} | ${cell(l.price)} | ${dealTypeLabel(l.dealType)} | ${cell(l.size)} | ${cell(l.provider)} | ${l.is_active ? 'yes' : 'no'} | ${cell(l.status?.status)} | ${formatDate(l.created_at)} | ${cell(l.job_name)} |\n`;
+      md += `| ${cell(l.id)} | ${cell(l.title)} | ${cell(l.address)} | ${cell(l.price)} | ${dealTypeLabel(l.dealType)} | ${cell(l.size)} | ${cell(l.provider)} | ${cell(internetCell(l))} | ${l.is_active ? 'yes' : 'no'} | ${cell(l.status?.status)} | ${formatDate(l.created_at)} | ${cell(l.job_name)} |\n`;
     }
     md += `\nUse **get_listing** with an ID for full details (description, link, image).\n`;
   } else {
@@ -178,6 +238,7 @@ export function normalizeGetListing(listing) {
   if (commute != null) {
     md += `- **Travel time:** ${commute}\n`;
   }
+  md += formatConnectivity(listing.connectivity);
 
   return toMcpResponse(md);
 }

--- a/test/api/mcpConnectivity.test.js
+++ b/test/api/mcpConnectivity.test.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 by Christian Kellner.
+ * Licensed under Apache-2.0 with Commons Clause and Attribution/Naming Clause
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+vi.mock('../../lib/services/storage/listingsStorage.js', () => ({
+  queryListings: vi.fn(() => ({ totalNumber: 0, page: 1, result: [] })),
+  getListingById: vi.fn(),
+}));
+vi.mock('../../lib/mcp/mcpAuthentication.js', () => ({
+  authenticateToolCall: vi.fn(() => ({ user: { id: 'u1', isAdmin: false } })),
+  checkJobAccess: vi.fn(() => true),
+}));
+
+import { queryListings } from '../../lib/services/storage/listingsStorage.js';
+import { filterMask } from '../../lib/services/connectivity/mobileBits.js';
+import { normalizeGetListing, normalizeListListings } from '../../lib/mcp/mcpNormalizer.js';
+import { createMcpServer } from '../../lib/mcp/mcpAdapter.js';
+
+async function callTool(name, args) {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0.0.0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  const result = await client.callTool({ name, arguments: args });
+  await client.close();
+  return result;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('list_listings connectivity filters', () => {
+  it('passes the downstream and fibre filters through to the query', async () => {
+    await callTool('list_listings', { minDownMbit: 100, fiberOnly: true });
+
+    expect(queryListings).toHaveBeenCalledOnce();
+    expect(queryListings.mock.calls[0][0]).toMatchObject({
+      connectivityMinDown: 100,
+      connectivityFiberOnly: true,
+    });
+  });
+
+  it('packs mobileTech and mobileOperator into the coverage bitmask', async () => {
+    await callTool('list_listings', { mobileTech: '5g', mobileOperator: 'dt' });
+
+    expect(queryListings.mock.calls[0][0].connectivityMobileMask).toBe(filterMask('5g', 'dt'));
+  });
+
+  it('packs a neutral (any-operator) mask when no operator is given', async () => {
+    await callTool('list_listings', { mobileTech: '4g' });
+
+    expect(queryListings.mock.calls[0][0].connectivityMobileMask).toBe(filterMask('4g', null));
+  });
+});
+
+describe('connectivity in tool output', () => {
+  const listing = {
+    id: 'l1',
+    title: 'Nice flat',
+    connectivity: {
+      maxDownMbit: 1000,
+      fiber: true,
+      mobile: {
+        neutral: { '2g': true, '4g': true, '5g': true, '5g_sa': false },
+        operators: {
+          dt: { '4g': true, '5g': true },
+          vf: { '4g': true, '5g': false },
+        },
+      },
+    },
+  };
+
+  it('renders a connectivity section in get_listing', () => {
+    const md = normalizeGetListing(listing).content[0].text;
+    expect(md).toMatch(/1000 Mbit\/s/);
+    expect(md).toMatch(/Fib(re|er)/i);
+    expect(md).toMatch(/5G/);
+    expect(md).toContain('Telekom');
+  });
+
+  it('shows a compact internet column in list_listings', () => {
+    const rows = { totalNumber: 1, result: [{ ...listing, connectivity_max_down: 1000, connectivity_fiber: 1 }] };
+    const md = normalizeListListings(rows, { page: 1, pageSize: 50 }).content[0].text;
+    expect(md).toMatch(/Internet/);
+    expect(md).toMatch(/1000/);
+  });
+});


### PR DESCRIPTION
## What

Fredy enriches listings with fixed-line and mobile coverage (the `connectivity_*` columns + `connectivity` JSON), and the web overview can filter on it — but the MCP interface did neither. A connected client could not answer "show me flats with fibre" or "does this address have 5G on Telekom". This wires that data into both listing tools.

## list_listings — new filters

| param | maps to | notes |
| --- | --- | --- |
| `minDownMbit` | `connectivityMinDown` | fixed-line downstream ≥ N Mbit/s |
| `fiberOnly` | `connectivityFiberOnly` | fibre to the building/home |
| `mobileTech` (`2g`/`4g`/`5g`/`5g_sa`) | `connectivityMobileMask` | packed via `filterMask()` |
| `mobileOperator` (`dt`/`vf`/`tf`/`ee`) | — | narrows `mobileTech` to one operator |

The client works in plain terms (`5g`, `dt`) and the adapter packs the coverage bitmask internally, so no raw masks leak into the tool schema. A compact **Internet** column (downstream + fibre marker) is added to the results table, read from the flat `connectivity_*` columns that `SELECT l.*` already carries.

## get_listing — new section

```
- Downstream: up to 1000 Mbit/s
- Fibre to the building: yes
- Mobile coverage: 5G (Telekom, Vodafone) · 4G (all operators) · 2G (available)
```

The mobile summary reads the parsed `connectivity` JSON and names operators per technology (newest first), collapsing "every operator" to "all operators".

## Testing

New `test/api/mcpConnectivity.test.js` covers the filter wiring (including the packed mask via `filterMask`) by driving the real server over an in-memory transport with a mocked query, plus both output paths. `TEST_MODE=offline npx vitest run test/api/mcpConnectivity.test.js` — 5 passing; the full MCP suite (17) stays green. Lint/format/copyright hooks pass.

Depends on nothing; independent of #435 and #436.