### PR TITLE
fix padding of Execution -> Working Hours

### DIFF
--- a/ui/src/views/admin/pages/ExecutionPage.jsx
+++ b/ui/src/views/admin/pages/ExecutionPage.jsx
@@ -17,7 +17,7 @@ import { timeZoneOptions } from '../../../services/time/timeService';
  */
 function formatFromTimestamp(ts) {
   const date = new Date(ts);
-  return `${date.getHours()}:${date.getMinutes() > 9 ? date.getMinutes() : '0' + date.getMinutes()}`;
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 }
 
 /**


### PR DESCRIPTION
Previously, only minutes were padded, hours were not. Thus, hours < 10 would be sent unpadded and fail the serverside validation:

    workingHours.from must be a time in HH:mm format.