### PR TITLE
fix(inberlinwohnen): normalize private search URLs

### DIFF
--- a/lib/provider/inberlinwohnen.js
+++ b/lib/provider/inberlinwohnen.js
@@ -322,6 +322,17 @@ function applyBlacklist(o, appliedBlackList) {
   return !isOneOf(o.title, appliedBlackList) && !isOneOf(o.description, appliedBlackList);
 }
 
+/**
+ * @param {string} url
+ * @returns {string}
+ */
+function normalizeSearchUrl(url) {
+  const parsed = new URL(url);
+  if (!['/mein-bereich/wohnungsfinder', '/mein-bereich/wohnungsfinder/'].includes(parsed.pathname)) return url;
+  parsed.pathname = '/wohnungsfinder/';
+  return parsed.href;
+}
+
 /** @type {ProviderConfig} */
 const config = {
   requiredFieldNames: ['id', 'link', 'title', 'price', 'size', 'rooms', 'address', 'image', 'description'],
@@ -353,7 +364,7 @@ const config = {
 export const createConfig = (sourceConfig, blacklist = []) => ({
   ...config,
   enabled: sourceConfig.enabled,
-  url: sourceConfig.url,
+  url: normalizeSearchUrl(sourceConfig.url),
   filter: (listing) => applyBlacklist(listing, blacklist ?? []),
 });
 

--- a/test/provider/inberlinwohnenInternals.test.js
+++ b/test/provider/inberlinwohnenInternals.test.js
@@ -37,6 +37,25 @@ describe('#inberlinwohnen internals()', () => {
     vi.restoreAllMocks();
   });
 
+  describe('createConfig()', () => {
+    it.each([
+      ['/mein-bereich/wohnungsfinder', '/wohnungsfinder/'],
+      ['/mein-bereich/wohnungsfinder/', '/wohnungsfinder/'],
+    ])('should replace the saved private search path %s', (privatePath, publicPath) => {
+      const privateUrl = `https://www.inberlinwohnen.de${privatePath}?q=opaque-filter&district=mitte`;
+
+      const privateRunConfig = provider.createConfig({ url: privateUrl, enabled: true }, []);
+
+      expect(privateRunConfig.url).toBe(`https://www.inberlinwohnen.de${publicPath}?q=opaque-filter&district=mitte`);
+    });
+
+    it('should leave public search URLs unchanged', () => {
+      const publicUrl = 'https://www.inberlinwohnen.de/wohnungsfinder/?q=opaque-filter&district=mitte';
+
+      expect(provider.createConfig({ url: publicUrl, enabled: true }, []).url).toBe(publicUrl);
+    });
+  });
+
   describe('getListings()', () => {
     it('should fetch every server-rendered result page', async () => {
       const pagination = paginationElement([1, 2, 3, 4, 5], 2);


### PR DESCRIPTION
## Summary

InBerlinWohnen returns `/mein-bereich/wohnungsfinder` URLs when users copy a search while logged in. That private route redirects Fredy's unauthenticated browser to the login page, preventing listing extraction.

This change:

- normalizes private search paths to `/wohnungsfinder/`;
- supports paths with or without a trailing slash;
- preserves the complete search query;
- leaves existing public search URLs unchanged.

## Test plan

- Added regression tests for both private path variants.
- Verified public URLs remain unchanged.
- Confirmed the regression test fails without the fix.
- Full offline suite: 2,380 passed, 32 skipped.
- ESLint and Prettier checks pass.
