### PR TITLE
fix(immoscout): decode URL-safe base64 shape parameter

### DIFF
--- a/lib/services/immoscout/shape.js
+++ b/lib/services/immoscout/shape.js
@@ -8,20 +8,48 @@
  */
 
 /**
- * A `shape` parameter carrying base64 rather than a bare polyline. The web UI writes the padding as
- * `.` instead of `=`, so up to two of them may trail the payload.
+ * A `shape` parameter carrying base64 rather than a bare polyline.
+ *
+ * ImmoScout writes the payload URL-safe, so besides the standard alphabet the value may contain `-`
+ * and `_`, and the padding arrives as `.` instead of `=` - up to two of them trailing the payload.
  * @type {RegExp}
  */
-const BASE64_SHAPE_PATTERN = /^[A-Za-z0-9+/]+\.{0,2}$/;
+const BASE64_SHAPE_PATTERN = /^[A-Za-z0-9+/_-]+\.{0,2}$/;
 
 /**
- * The alphabet of a Google Encoded Polyline. Every character is a 6 bit chunk plus 63, so the whole
- * string lives between `?` and `~`. Digits, `+` and `=` can therefore never appear in one, and none
- * of `?@[\]^_{|}~` can appear in base64, which is what makes the two shape flavours tellable apart
- * without having to ask ImmoScout which one it sent.
+ * The alphabet of a Google Encoded Polyline. Every character is a 5 bit chunk plus a continuation
+ * bit plus 63, so the whole string lives between `?` and `~`. Digits, `+` and `=` can therefore
+ * never appear in one, and none of `?@[\]^{|}~` can appear in base64, which is what tells the two
+ * shape flavours apart.
+ *
+ * `_` is the one character both alphabets share, so admitting it above costs some of that
+ * separation - a raw polyline containing `_` is now offered to the decoder. Nothing is lost by it:
+ * a decode is only kept when it is itself a valid polyline, and `-` cannot occur in a polyline at
+ * all, so admitting that one is free.
  * @type {RegExp}
  */
 const POLYLINE_PATTERN = /^[\x3f-\x7e]+$/;
+
+/**
+ * The URL-safe substitutions to undo, most likely first.
+ *
+ * ImmoScout maps `+` to `_` - confirmed against the `lastSearchApiUrl` its own search pages embed,
+ * where a shape carrying `_` resolves to a polyline byte of `0x7e`. Reading that `_` as base64url's
+ * `/` instead yields `0x7f`, one past the end of the polyline alphabet, and the mobile API answers
+ * `500`. The counterpart `-` never showed up in a sample, hence the base64url candidate behind it.
+ * @type {Array<Array<[RegExp, string]>>}
+ */
+const URL_SAFE_ALPHABETS = [
+  [
+    [/_/g, '+'],
+    [/-/g, '/'],
+  ],
+  [
+    [/-/g, '+'],
+    [/_/g, '/'],
+  ],
+  [],
+];
 
 /**
  * The polyline behind a web URL's `shape` parameter.
@@ -32,7 +60,7 @@ const POLYLINE_PATTERN = /^[\x3f-\x7e]+$/;
  * bytes left over are not valid UTF-8, so the shape reaches the mobile API as a run of U+FFFD
  * (`%EF%BF%BD` once encoded) and it answers `400 Cannot parse shape`. Decoding is therefore only
  * attempted when the input could be base64 at all, and the result is only kept when it decodes to
- * something a polyline could be.
+ * something a polyline could be. That check is also what makes trying more than one alphabet safe.
  *
  * @param {string} shape Raw value of the web URL's `shape` query parameter.
  * @returns {string} The polyline to hand to the mobile API.
@@ -40,6 +68,15 @@ const POLYLINE_PATTERN = /^[\x3f-\x7e]+$/;
 export function toPolyline(shape) {
   if (!BASE64_SHAPE_PATTERN.test(shape)) return shape;
 
-  const decoded = Buffer.from(shape.replace(/\.\./g, '==').replace(/\./g, '='), 'base64').toString('utf-8');
-  return POLYLINE_PATTERN.test(decoded) ? decoded : shape;
+  const padded = shape.replace(/\.\./g, '==').replace(/\./g, '=');
+
+  for (const substitutions of URL_SAFE_ALPHABETS) {
+    // `Buffer.from(x, 'base64')` reads `-` and `_` as base64url on its own, so the substitutions
+    // have to be applied rather than relied upon.
+    const candidate = substitutions.reduce((value, [from, to]) => value.replace(from, to), padded);
+    const decoded = Buffer.from(candidate, 'base64').toString('utf-8');
+    if (POLYLINE_PATTERN.test(decoded)) return decoded;
+  }
+
+  return shape;
 }

--- a/test/services/immoscout/shape.test.js
+++ b/test/services/immoscout/shape.test.js
@@ -50,9 +50,42 @@ describe('#immoscout shape parameter', () => {
     expect(toPolyline(shape)).toBe(shape);
   });
 
-  // The two alphabets overlap on letters alone, so the characters that appear in only one of them
-  // are what decides. A polyline containing any of `?@[\]^_{|}~` can never be read as base64.
+  // The two alphabets overlap on letters and on `_`, so the characters that appear in only one of
+  // them are what decides. A polyline containing any of `?@[\]^{|}~` can never be read as base64.
   it.each(['?@[\\]^_{|}~', 'ior~H_kxmAr`Pig`@fzH', 'a@b?c~d'])('should treat %s as a polyline', (shape) => {
     expect(toPolyline(shape)).toBe(shape);
+  });
+
+  // ImmoScout writes the payload URL-safe, mapping `+` to `_`. Reading that `_` as base64url's `/`
+  // instead lands one past the end of the polyline alphabet and the mobile API answers 500, which
+  // is what this shape - a drawn area in Hamburg Altona - used to do. The expectation is the
+  // polyline ImmoScout's own search page resolves it to, taken from its `lastSearchApiUrl`.
+  it('should decode a shape using ImmoScout url-safe alphabet', () => {
+    const shape =
+      'X3p7ZUl5aWF7QGp9QXtoRmtFeX5OcWZAfWJDdWpCfXtNZV9Cblxfd0BsaUN0S3R_SH5tQWpqSGNSdG1DeUJicURmQGVQdFRmc0RsfUBgakE.';
+
+    expect(toPolyline(shape)).toBe('_z{eIyia{@j}A{hFkEy~Nqf@}bCujB}{Me_Bn\\_w@liCtKt~H~mAjjHcRtmCyBbqDf@ePtTfsDl}@`jA');
+  });
+
+  // The `-` counterpart never turned up in a sample, so base64url is tried behind ImmoScout's own
+  // mapping rather than instead of it. Either way the decode has to be a polyline to be kept.
+  it('should decode a base64url shape', () => {
+    const polyline = 'ymrwHidih@`IkS_Aal@oTsVoViClw@g?~';
+    const encoded = Buffer.from(polyline, 'utf-8').toString('base64url');
+    expect(encoded).toContain('-');
+
+    expect(toPolyline(encoded)).toBe(polyline);
+  });
+
+  // Every byte a polyline can carry is a 5 bit chunk plus a continuation bit plus 63, so anything
+  // outside `?`..`~` means the wrong alphabet was read and the decode must not be handed on.
+  it.each([
+    'X3p7ZUl5aWF7QGp9QXtoRmtFeX5OcWZAfWJDdWpCfXtNZV9Cblxfd0BsaUN0S3R_SH5tQWpqSGNSdG1DeUJicURmQGVQdFRmc0RsfUBgakE.',
+    'aW9yfkhfa3htQXJgUGlnYEBmekhte3BAcXNAfWBsQGNyQ2lkUHVvbEB3eX5Ab25WYn5Fa2BLaGRQY29FaGtTfEhme3xBdHBEdHFMamlHbmdRfHhMcmxPeHlWYnpS',
+  ])('should never return a byte outside the polyline alphabet for %s', (shape) => {
+    for (const character of toPolyline(shape)) {
+      expect(character.charCodeAt(0)).toBeGreaterThanOrEqual(0x3f);
+      expect(character.charCodeAt(0)).toBeLessThanOrEqual(0x7e);
+    }
   });
 });


### PR DESCRIPTION
Immoscout drawn-area (shape) searches were returning 500 from the mobile API, which looked like IP blocking but wasn't. 

Immoscout encodes the shape parameter with a URL-safe base64 variant (+→_), but `toPolyline()` only recognized standard base64, so such values passed through undecoded and the mobile API rejected them. `toPolyline()` now tries Immoscout's alphabet, then base64url, then no substitution, keeping whichever decode yields a valid polyline; verified against the real API and Immoscout's own resolved-query output (`lastSearchApiUrl`).